### PR TITLE
Fixed iOS5 crash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,11 +7,3 @@ MessagesDemo.xcodeproj/xcuserdata/jesse.xcuserdatad/
 /MessagesDemoStoryboards/build/
 /MessagesDemoStoryboards/MessagesDemoSB.xcodeproj/project.xcworkspace/xcuserdata/jesse.xcuserdatad/
 /MessagesDemoStoryboards/MessagesDemoSB.xcodeproj/xcuserdata/jesse.xcuserdatad/
-
-/DerivedData
-
-MessagesDemo.xcodeproj/xcuserdata/oleg.xcuserdatad/xcschemes/xcschememanagement.plist
-
-MessagesDemo.xcodeproj/xcuserdata/oleg.xcuserdatad/xcschemes/MessagesDemo.xcscheme
-
-MessagesDemo.xcodeproj/project.xcworkspace/xcuserdata/oleg.xcuserdatad/UserInterfaceState.xcuserstate


### PR DESCRIPTION
makeStretchable\* methods from UIImage+JSMessagesView crash in iOS5.
The reason is `resizableImageWithCapInsets:resizingMode:` defined starting iOS6 only. 
