### PR TITLE
calculate the UITextView contentSize by ourselves because of an iOS7 problem

### DIFF
--- a/JSMessagesTableViewController/JSMessagesViewController.m
+++ b/JSMessagesTableViewController/JSMessagesViewController.m
@@ -421,4 +421,6 @@
     self.inputToolBarView.frame = inputViewFrame;
 }
 
+
+
 @end


### PR DESCRIPTION
iOS7 seam to have a problem calculation the content size with line two and three. It reported the wrong height, reducing it until zero and increasing it again. Looking at the developer forum it seams a known bug. 
