### PR TITLE
Update JSMessagesViewController.m

### DIFF
--- a/JSMessagesViewController/Classes/JSMessagesViewController.m
+++ b/JSMessagesViewController/Classes/JSMessagesViewController.m
@@ -562,10 +562,14 @@
 
 - (void)keyboardWillSnapBackToPoint:(CGPoint)point
 {
-    CGRect inputViewFrame = self.messageInputView.frame;
-    CGPoint keyboardOrigin = [self.view convertPoint:point fromView:nil];
-    inputViewFrame.origin.y = keyboardOrigin.y - inputViewFrame.size.height;
-    self.messageInputView.frame = inputViewFrame;
+    if([[[self.parentViewController tabBarController] tabBar] isHidden]){
+        CGRect inputViewFrame = self.messageInputView.frame;
+        CGPoint keyboardOrigin = [self.view convertPoint:point fromView:nil];
+        inputViewFrame.origin.y = keyboardOrigin.y - inputViewFrame.size.height;
+        self.messageInputView.frame = inputViewFrame;
+    }
+    else{
+    }
 }
 
 #pragma mark - Utilities


### PR DESCRIPTION
Edit keyboardWillSnapBackToPoint to first check for the existence of a tabBarController in the parent view. If one exists, don't adjust the frame since it will put the messageInputView behind the tab bar.
