### PR TITLE
Fix #94

### DIFF
--- a/JSMessagesViewController/Classes/JSMessagesViewController.m
+++ b/JSMessagesViewController/Classes/JSMessagesViewController.m
@@ -569,6 +569,10 @@
 
 - (void)keyboardWillSnapBackToPoint:(CGPoint)point
 {
+    if(self.parentViewController != nil && !self.parentViewController.tabBarController.tabBar.isHidden){
+        return;
+    }
+	
     CGRect inputViewFrame = self.messageInputView.frame;
     CGPoint keyboardOrigin = [self.view convertPoint:point fromView:nil];
     inputViewFrame.origin.y = keyboardOrigin.y - inputViewFrame.size.height;


### PR DESCRIPTION
Prevent frame resize on keyboard WillSnapBackToPoint when the MessageViewController is embedded within a TabBarController
