### PR TITLE
Fix scroll to bottom issue if layout changes view size.

### DIFF
--- a/JSMessagesViewController/Classes/JSMessagesViewController.m
+++ b/JSMessagesViewController/Classes/JSMessagesViewController.m
@@ -20,6 +20,7 @@
 
 @property (assign, nonatomic) CGFloat previousTextViewContentHeight;
 @property (assign, nonatomic) BOOL isUserScrolling;
+@property (assign, nonatomic) BOOL isViewAppeared;
 
 - (void)setup;
 
@@ -115,8 +116,6 @@
 {
     [super viewWillAppear:animated];
     
-    [self scrollToBottomAnimated:NO];
-    
 	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(handleWillShowKeyboardNotification:)
 												 name:UIKeyboardWillShowNotification
@@ -128,6 +127,12 @@
                                                object:nil];
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+    [super viewDidAppear:animated];
+    self.isViewAppeared = YES;
+}
+
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
@@ -137,6 +142,12 @@
     
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillShowNotification object:nil];
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:UIKeyboardWillHideNotification object:nil];
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+    [super viewDidDisappear:animated];
+    self.isViewAppeared = NO;
 }
 
 - (void)didReceiveMemoryWarning
@@ -160,6 +171,9 @@
 {
     [super viewWillLayoutSubviews];
     [self setTableViewInsetsWithBottomValue:0.0f];
+    if (!self.isViewAppeared) {
+        [self scrollToBottomAnimated:NO];
+    }
 }
 
 #pragma mark - View rotation


### PR DESCRIPTION
If, for example on the iPhone 5, the initial layout enlarges the view, then the initial scroll-to-bottom call leaves the table view scrolled to something that is not quite the end (offset by the change in size). On the initial layout only we should trigger the scroll-to-bottom rather than in the viewWillAppear callback.
