### PR TITLE
Fix scrolling issue

### DIFF
--- a/JSMessagesViewController/Classes/JSMessagesViewController.m
+++ b/JSMessagesViewController/Classes/JSMessagesViewController.m
@@ -116,6 +116,8 @@
     [super viewWillAppear:animated];
     
     [self scrollToBottomAnimated:NO];
+
+    [self.tableView setContentOffset:CGPointMake(0, CGFLOAT_MAX)];
     
 	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(handleWillShowKeyboardNotification:)


### PR DESCRIPTION
After navigating back to MessagesTableViewController, the tableView does not scroll to the bottom exactly (usually one cell off, see [this screecast](http://d.pr/v/5uu9)).

This commit fix this issue.
