### PR TITLE
tableView frame size should be the same as it's container view frame size.

### DIFF
--- a/JSMessagesViewController/Classes/JSMessagesViewController.h
+++ b/JSMessagesViewController/Classes/JSMessagesViewController.h
@@ -117,6 +117,15 @@
  */
 - (NSString *)customCellIdentifierForRowAtIndexPath:(NSIndexPath *)indexPath;
 
+/**
+ *  Ask the delegate for an additional condition check for enabling the Send button.
+ *  You may account for network connectivity here, etc.
+ *
+ *  @return A boolean value specifying whether the send button can be enabled or not.
+ */
+- (BOOL)allowSendButtonEnabling;
+
+
 @end
 
 

--- a/JSMessagesViewController/Classes/JSMessagesViewController.m
+++ b/JSMessagesViewController/Classes/JSMessagesViewController.m
@@ -362,7 +362,11 @@
 
 - (void)textViewDidChange:(UITextView *)textView
 {
-    self.messageInputView.sendButton.enabled = ([[textView.text js_stringByTrimingWhitespace] length] > 0);
+    BOOL secondCondition = YES;
+    if ([self.delegate respondsToSelector:@selector(allowSendButtonEnabling)])
+        secondCondition = [self.delegate allowSendButtonEnabling];
+    
+    self.messageInputView.sendButton.enabled = ([[textView.text js_stringByTrimingWhitespace] length] > 0) && secondCondition;
 }
 
 - (void)textViewDidEndEditing:(UITextView *)textView


### PR DESCRIPTION
No reason to reduce tableView frame height in account for the inputView height as we are already modifying
the bottom content insets, all we need is to increase the insets by inputView height.

Added another commit which adds an optional additional condition to be provided by user for enabling the Send button. This is where network connectivity condition may be implemented.
