### PR TITLE
allow auto-scroll to be disabled via the delegate

### DIFF
--- a/JSMessagesViewController/Classes/JSMessagesViewController.h
+++ b/JSMessagesViewController/Classes/JSMessagesViewController.h
@@ -95,6 +95,13 @@
 - (BOOL)shouldPreventScrollToBottomWhileUserScrolling;
 
 /**
+ *  Asks the delegate if should scroll to the bottom automatically when the view appears.  Default behavior is YES.
+ *
+ *  @return `YES` if you would like to prevent the table view from being scrolled to the bottom while the screen is displayed, `NO` otherwise.
+ */
+- (BOOL)shouldAutoScrollToBottom;
+
+/**
  *  Ask the delegate if the keyboard should be dismissed by panning/swiping downward. The default value is `YES`. Return `NO` to dismiss the keyboard by tapping.
  *
  *  @return A boolean value specifying whether the keyboard should be dismissed by panning/swiping.

--- a/JSMessagesViewController/Classes/JSMessagesViewController.m
+++ b/JSMessagesViewController/Classes/JSMessagesViewController.m
@@ -125,7 +125,8 @@
 {
     [super viewWillAppear:animated];
     
-    [self scrollToBottomAnimated:NO];
+    if ([self shouldAllowScroll])
+        [self scrollToBottomAnimated:NO];
     
 	[[NSNotificationCenter defaultCenter] addObserver:self
 											 selector:@selector(handleWillShowKeyboardNotification:)
@@ -136,13 +137,6 @@
 											 selector:@selector(handleWillHideKeyboardNotification:)
 												 name:UIKeyboardWillHideNotification
                                                object:nil];
-}
-
-- (void)viewDidAppear:(BOOL)animated
-{
-    [super viewDidAppear:animated];
-    
-    [self scrollToBottomAnimated:YES];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -329,6 +323,11 @@
            && [self.delegate shouldPreventScrollToBottomWhileUserScrolling]) {
             return NO;
         }
+    }
+  
+    if ([self.delegate respondsToSelector:@selector(shouldAutoScrollToBottom)] &&
+        ![self.delegate shouldAutoScrollToBottom]) {
+        return NO;
     }
     
     return YES;


### PR DESCRIPTION
Added a delegate method to potentially stop scrolling to the bottom on viewWillAppear every single time.  This is used in our project for tapping an image and seeing sub-screen details with a nav controller push, then going back to wherever you were in the scrolling view on return.
