### PR TITLE
Fix distortion of placeholder in landscape orientation

### DIFF
--- a/JSMessagesDemo/JSDemoViewController.m
+++ b/JSMessagesDemo/JSDemoViewController.m
@@ -201,4 +201,15 @@
     return [[UIImageView alloc] initWithImage:image];
 }
 
+#pragma mark - View rotation
+
+- (BOOL)shouldAutorotate
+{
+    return YES;
+}
+
+- (NSUInteger)supportedInterfaceOrientations
+{
+    return UIInterfaceOrientationMaskAll;
+}
 @end

--- a/JSMessagesDemo/JSMessagesDemo-Info.plist
+++ b/JSMessagesDemo/JSMessagesDemo-Info.plist
@@ -31,6 +31,9 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/JSMessagesViewController/Classes/JSMessageTextView.m
+++ b/JSMessagesViewController/Classes/JSMessageTextView.m
@@ -49,6 +49,7 @@
     self.keyboardType = UIKeyboardTypeDefault;
     self.returnKeyType = UIReturnKeyDefault;
     self.textAlignment = NSTextAlignmentLeft;
+    self.contentMode = UIViewContentModeRedraw;
     
     [self addTextViewNotificationObservers];
 }


### PR DESCRIPTION
When rotation was enabled, placeholder was distorted on iOS 7.x in landscape mode. By changing the text view’s contentMode to UIViewContentModeRedraw, the distortion goes away. Some similar bug aws fixed in HPGrowingTextView (https://github.com/HansPinckaers/GrowingTextView/commit/ade5112444112409b617020a1960fe1ca4afe11e).
The modification in JSDemoViewController.m and JSMessagesDemo-Info.plist are just to demonstrate that it works.
