### PR TITLE
changed viewWillDissappear to viewDidDissappear as the former is not always called

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -165,9 +165,9 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     self.collectionView.collectionViewLayout.springinessEnabled = YES;
 }
 
-- (void)viewWillDisappear:(BOOL)animated
+- (void)viewDidDisappear:(BOOL)animated
 {
-    [super viewWillDisappear:animated];
+    [super viewDidDisappear:animated];
     [self.view removeKeyboardControl];
     [self jsq_removeObservers];
 }


### PR DESCRIPTION
Tested on iOS 7.1 in a custom project where JSQMessagesViewController was being presented via push segue within a navigation controller.

When tapping back, viewWillDissappear was not called 100% of the time, therefore leaving dangling KVOs and hence serious memory leaks. Although I cannot reproduce this bug in the demo project, I'm wary that viewWillAppear is one of the most misunderstood methods especially in iOS7.

If this passes tests on the Demo project, I'd love it to be merged.
