### PR TITLE
issue_219_fix - Additional status bar height

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -250,7 +250,9 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
 {
     CGPoint touch = [pan locationInView:nil];
     
-    CGFloat contextViewHeight = CGRectGetHeight(self.contextView.frame);
+    CGFloat additionalStatusBarHeight = CGRectGetHeight([UIApplication sharedApplication].statusBarFrame) - 20.0f;
+    
+    CGFloat contextViewHeight = CGRectGetHeight(self.contextView.frame) + additionalStatusBarHeight;
     CGFloat keyboardViewHeight = CGRectGetHeight(self.keyboardView.frame);
     
     CGRect newKeyboardViewFrame = self.keyboardView.frame;

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -503,12 +503,14 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (void)keyboardDidChangeFrame:(CGRect)keyboardFrame
 {
+    CGFloat additionalStatusBarHeight = CGRectGetHeight([UIApplication sharedApplication].statusBarFrame) - 20.0f;
+    
     CGRect newToolbarFrame = self.inputToolbar.frame;
-    newToolbarFrame.origin.y = CGRectGetMinY(keyboardFrame) - CGRectGetHeight(newToolbarFrame);
+    newToolbarFrame.origin.y = CGRectGetMinY(keyboardFrame) - CGRectGetHeight(newToolbarFrame) - additionalStatusBarHeight;
     
     self.inputToolbar.frame = newToolbarFrame;
     
-    CGFloat heightFromBottom = CGRectGetHeight(self.view.frame) - CGRectGetMinY(keyboardFrame);
+    CGFloat heightFromBottom = CGRectGetHeight(self.view.frame) - CGRectGetMinY(keyboardFrame) + additionalStatusBarHeight;
     self.toolbarBottomLayoutGuide.constant = heightFromBottom;
     [self.view setNeedsUpdateConstraints];
     


### PR DESCRIPTION
When the status bar height is doubled (40 instead of 20), the
calculated location of the inputToolbar is 20 points lower than it
should be. I don’t like hardcoding the default status bar height
(20.0f), but couldn’t find a way to get it.

I tested the follow two cases:
- Status bar height changes due to incoming phone call (in simulator Hardware --> Toggle In-Call Status Bar).
- Status bar height is larger before loading/viewing the MessagesChatView, when the "Personal Hotspot" is already status bar is showing.
