### PR TITLE
issue_213_fix - Check if keyboard is visible before animations

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -282,8 +282,7 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
         case UIGestureRecognizerStateCancelled:
         case UIGestureRecognizerStateFailed:
         {
-            BOOL keyboardViewIsHidden = (CGRectGetHeight(self.contextView.frame) - CGRectGetMinY(self.keyboardView.frame) <= 0.0f);
-            
+            BOOL keyboardViewIsHidden = (CGRectGetMinY(self.keyboardView.frame) >= CGRectGetMaxY(self.contextView.frame));
             if(keyboardViewIsHidden) {
                 return;
             }


### PR DESCRIPTION
Check if keyboard is visible before performing animations on it after
UIGestureRecognizerStateEnded.
When the user swipes down too fast, the keyboard is no longer visible,
but jsq_handlePanGestureRecognizer:(UIPanGestureRecognizer *)pan still
tried to animate it.
