### PR TITLE
Added a protocol method to allow overriding of isOutgoingMessage

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -373,6 +373,10 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     
     BOOL isOutgoingMessage = [messageSender isEqualToString:self.sender];
     
+    if ( [collectionView.dataSource respondsToSelector:@selector(collectionView:isOutgoingMessageAtIndexPath:)] ) {
+        isOutgoingMessage = [collectionView.dataSource collectionView:collectionView isOutgoingMessageAtIndexPath:indexPath];
+    }
+    
     NSString *cellIdentifier = isOutgoingMessage ? self.outgoingCellIdentifier : self.incomingCellIdentifier;
     JSQMessagesCollectionViewCell *cell = [collectionView dequeueReusableCellWithReuseIdentifier:cellIdentifier forIndexPath:indexPath];
     cell.delegate = self;

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.h
@@ -140,6 +140,16 @@
  */
 - (NSAttributedString *)collectionView:(JSQMessagesCollectionView *)collectionView attributedTextForCellBottomLabelAtIndexPath:(NSIndexPath *)indexPath;
 
+/**
+ * Asks the data source if this message is outgoing or not.
+ *
+ *  @param collectionView The object representing the collection view requestthis information
+ *  @param indexPath      The index path that specifies the location of the item.
+ *
+ *  @return YES if is outgoing, NO if incoming,
+ */
+- (BOOL)collectionView:(JSQMessagesCollectionView *)collectionView isOutgoingMessageAtIndexPath:(NSIndexPath *)indexPath;
+
 @end
 
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,5 +1,5 @@
 PODS:
-  - JSQSystemSoundPlayer (1.4.0)
+  - JSQSystemSoundPlayer (1.5.0)
   - OCMock (2.2.4)
 
 DEPENDENCIES:
@@ -7,7 +7,7 @@ DEPENDENCIES:
   - OCMock
 
 SPEC CHECKSUMS:
-  JSQSystemSoundPlayer: 28ccd01a92a0cebc6de6361e8499011b4cb6dab7
+  JSQSystemSoundPlayer: 6dbac8dcc33e3add6facb3e59451a0249aece17d
   OCMock: 5008fae4b4789b8fc3e48cd7660f2eb5ef8ce89e
 
 COCOAPODS: 0.32.1


### PR DESCRIPTION
I have a scenario where the default behavior for figuring out incoming and outgoing will not work so I added an optional delegate method that would let me override that value.

ps. I have never submitted a pull request before.
