### PR TITLE
Use balanced KVO registration/deregistration calls to prevent unnecessary exceptions from being thrown

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -233,7 +233,9 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if (context == kJSQMessagesKeyboardControllerKeyValueObservingContext) {
+    if (context == kJSQMessagesKeyboardControllerKeyValueObservingContext
+        && object == _keyboardView
+        && [keyPath isEqualToString:NSStringFromSelector(@selector(frame))]) {
         
         CGRect oldKeyboardFrame = [[change objectForKey:NSKeyValueChangeOldKey] CGRectValue];
         CGRect newKeyboardFrame = [[change objectForKey:NSKeyValueChangeNewKey] CGRectValue];

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -580,7 +580,9 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if (context == kJSQMessagesKeyValueObservingContext) {
+    if (context == kJSQMessagesKeyValueObservingContext
+        && object == self.inputToolbar.contentView.textView
+        && [keyPath isEqualToString:NSStringFromSelector(@selector(contentSize))]) {
         
         CGSize oldContentSize = [[change objectForKey:NSKeyValueChangeOldKey] CGSizeValue];
         CGSize newContentSize = [[change objectForKey:NSKeyValueChangeNewKey] CGSizeValue];

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
@@ -108,7 +108,9 @@ static void * kJSQMessagesInputToolbarRightBarButtonItemKeyValueObservingContext
 
 - (void)observeValueForKeyPath:(NSString *)keyPath ofObject:(id)object change:(NSDictionary *)change context:(void *)context
 {
-    if (context == kJSQMessagesInputToolbarLeftBarButtonItemKeyValueObservingContext) {
+    if (context == kJSQMessagesInputToolbarLeftBarButtonItemKeyValueObservingContext
+        && object == self.contentView
+        && [keyPath isEqualToString:NSStringFromSelector(@selector(leftBarButtonItem))]) {
         
         [self.contentView.leftBarButtonItem removeTarget:self
                                                   action:NULL
@@ -117,7 +119,9 @@ static void * kJSQMessagesInputToolbarRightBarButtonItemKeyValueObservingContext
         [self.contentView.leftBarButtonItem addTarget:self
                                                action:@selector(jsq_leftBarButtonPressed:)
                                      forControlEvents:UIControlEventTouchUpInside];
-    } else if (context == kJSQMessagesInputToolbarRightBarButtonItemKeyValueObservingContext) {
+    } else if (context == kJSQMessagesInputToolbarRightBarButtonItemKeyValueObservingContext
+               && object == self.contentView
+               && [keyPath isEqualToString:NSStringFromSelector(@selector(rightBarButtonItem))] ) {
         [self.contentView.rightBarButtonItem removeTarget:self
                                                    action:NULL
                                          forControlEvents:UIControlEventTouchUpInside];


### PR DESCRIPTION
Fixes #285.

Contains a number of changes:
- Each class using KVO now registers and deregisters in a balanced fashion. Classes no longer attempt to remove non-existent observances.
- Classes now only use the `context` parameter to determine if an observation event is one that they should handle. There is now a context pointer for each observation type.
- Classes now correctly call super in `- (void)observeValueForKeyPath:ofObject:change:context:`.
