### PR TITLE
Add top content inset support

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -114,6 +114,14 @@
  */
 @property (assign, nonatomic) BOOL showLoadEarlierMessagesHeader;
 
+/**
+ * Specifies an extra space to be added to the calculated contentInsets.top of this view controller's
+ * collectionView.
+ * @discussion Use this if you have any view on top of this view controller's collectionView and you want upper
+ * messages to be displayed correctly.
+ */
+@property (assign, nonatomic) CGFloat extraTopContentInset;
+
 #pragma mark - Class methods
 
 /**

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -312,9 +312,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     NSInteger items = [self.collectionView numberOfItemsInSection:0];
     
     if (items > 0) {
-        [self.collectionView scrollToItemAtIndexPath:[NSIndexPath indexPathForItem:items - 1 inSection:0]
-                                    atScrollPosition:UICollectionViewScrollPositionTop
-                                            animated:animated];
+        [self.collectionView scrollRectToVisible:CGRectMake(0, self.collectionView.contentSize.height - 1, 1, 1)
+                                        animated:animated];
     }
 }
 
@@ -728,7 +727,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (void)jsq_updateCollectionViewInsets
 {
-    [self jsq_setCollectionViewInsetsTopValue:self.topLayoutGuide.length
+    [self jsq_setCollectionViewInsetsTopValue:self.topLayoutGuide.length + self.extraTopContentInset
                                   bottomValue:CGRectGetHeight(self.collectionView.frame) - CGRectGetMinY(self.inputToolbar.frame)];
 }
 


### PR DESCRIPTION
I added a simple property that is supposed to be set before [super viewDidLoad] is called on the class that inherits from JSQMessagesViewController. When tried this for the first time, the scrolling to bottom functionality didn't work, so I fixed it by using a scrollRectToVisible:animated: method call. My particular need was to have a view on top of the collection view, and have the top contentInset of the collection view value to take this into account.
