### PR TITLE
Fix opaque navbar

### DIFF
--- a/JSQMessagesDemo/Base.lproj/Main.storyboard
+++ b/JSQMessagesDemo/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5056" systemVersion="13E28" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="JRd-Be-psV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="5053" systemVersion="13C64" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="JRd-Be-psV">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="3733"/>
     </dependencies>

--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -210,14 +210,12 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
     
     double animationDuration = [userInfo[UIKeyboardAnimationDurationUserInfoKey] doubleValue];
     
-    CGRect keyboardEndFrameConverted = keyboardEndFrame;
-    
     [UIView animateWithDuration:animationDuration
                           delay:0.0
                         options:animationCurveOption
                      animations:^{
-                         [self.delegate keyboardDidChangeFrame:keyboardEndFrameConverted];
-                         [self jsq_postKeyboardFrameNotificationForFrame:keyboardEndFrameConverted];
+                         [self.delegate keyboardDidChangeFrame:keyboardEndFrame];
+                         [self jsq_postKeyboardFrameNotificationForFrame:keyboardEndFrame];
                      }
                      completion:^(BOOL finished) {
                          if (completion) {
@@ -285,10 +283,10 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
 
 - (void)jsq_handlePanGestureRecognizer:(UIPanGestureRecognizer *)pan
 {
-    CGFloat yOffset = self.contextView.frame.origin.y;
-
+    CGFloat contextViewOriginY = CGRectGetMinY(self.contextView.frame);
+    
     CGPoint touch = [pan locationInView:self.contextView];
-    touch = CGPointMake(touch.x, touch.y + yOffset);
+    touch = CGPointMake(touch.x, touch.y + contextViewOriginY);
 
     //  system keyboard is added to a new UIWindow, need to operate in window coordinates
     //  also, keyboard always slides from bottom of screen, not the bottom of a view
@@ -299,7 +297,7 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
     
     CGFloat keyboardViewHeight = CGRectGetHeight(self.keyboardView.frame);
     
-    CGFloat dragThresholdY = (contextViewWindowHeight - keyboardViewHeight - self.keyboardTriggerPoint.y - yOffset);
+    CGFloat dragThresholdY = (contextViewWindowHeight - keyboardViewHeight - self.keyboardTriggerPoint.y - contextViewOriginY);
     
     CGRect newKeyboardViewFrame = self.keyboardView.frame;
     


### PR DESCRIPTION
The math behind calculating how much of the keyboard was covering the UIScrollView was being done in different coordinates, which was working when the UINavigationBar is translucent because the UIViewController's view covers the whole UIWindow, but not when that is opaque. 

Also updated the math calculating the UIKeyboard's Y position while being dragged.

Fixes bug #405
