### PR TITLE
delegate menu actions to ViewController

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -469,6 +469,25 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     return NO;
 }
 
+- (BOOL)collectionView:(UICollectionView *)collectionView shouldShowMenuForItemAtIndexPath:(NSIndexPath *)indexPath
+{
+    return YES;
+}
+
+- (BOOL)collectionView:(UICollectionView *)collectionView canPerformAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender
+{
+    return (action == @selector(copy:));
+}
+
+- (void)collectionView:(UICollectionView *)collectionView performAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender
+{
+    JSQMessagesCollectionViewCell *cell = (JSQMessagesCollectionViewCell *)[self.collectionView cellForItemAtIndexPath:indexPath];
+    if (action == @selector(copy:)) {
+        [[UIPasteboard generalPasteboard] setString:cell.textView.text];
+        [cell resignFirstResponder];
+    }
+}
+
 #pragma mark - Collection view delegate flow layout
 
 - (CGSize)collectionView:(JSQMessagesCollectionView *)collectionView

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
@@ -136,4 +136,22 @@
                     touchLocation:position];
 }
 
+- (BOOL)shouldShowMenuForCell:(JSQMessagesCollectionViewCell *)cell
+{
+    NSIndexPath *indexPath = [self indexPathForCell:cell];
+    return [self.delegate collectionView:self shouldShowMenuForItemAtIndexPath:indexPath];
+}
+
+- (BOOL)canPerformAction:(SEL)action forCell:(JSQMessagesCollectionViewCell *)cell withSender:(id)sender
+{
+    NSIndexPath *indexPath = [self indexPathForCell:cell];
+    return [self.delegate collectionView:self canPerformAction:action forItemAtIndexPath:indexPath withSender:sender];
+}
+
+- (void)performAction:(SEL)action forCell:(UICollectionViewCell *)cell withSender:(id)sender
+{
+    NSIndexPath *indexPath = [self indexPathForCell:cell];
+    [self.delegate collectionView:self performAction:action forItemAtIndexPath:indexPath withSender:sender];
+}
+
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
@@ -59,6 +59,12 @@
  */
 - (void)messagesCollectionViewCellDidTapCell:(JSQMessagesCollectionViewCell *)cell atPosition:(CGPoint)position;
 
+- (BOOL)shouldShowMenuForCell:(JSQMessagesCollectionViewCell *)cell;
+
+- (BOOL)canPerformAction:(SEL)action forCell:(JSQMessagesCollectionViewCell *)cell withSender:(id)sender;
+
+- (void)performAction:(SEL)action forCell:(JSQMessagesCollectionViewCell *)cell withSender:(id)sender;
+
 @end
 
 


### PR DESCRIPTION
The basic idea is to show the menu from the cell, but delegate shouldShowMenu/canPerformAction/performAction to the ViewController, as iOS would do and has methods for on UICollectionViewDelegate.

The ActionTarget hack I'm not terribly pleased with. UICollectionViewCell has an undocumented _performAction:sender: which would be perfect for this, but I don't know if overriding it is kosher with the App Store.

If that's ok to use, then all the ActionTarget stuff and targetForAction can be removed and replaced with a simple:

``` objc
- (void)_performAction:(SEL)action sender:(id)sender
{
    [self.delegate performAction:action forCell:self withSender:sender];
}
```
