### PR TITLE
accept autocorrect by resigning/becoming first responder

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -542,10 +542,12 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (NSString *)jsq_currentlyComposedMessageText
 {
-    //  add a space to accept any auto-correct suggestions
-    NSString *text = self.inputToolbar.contentView.textView.text;
-    self.inputToolbar.contentView.textView.text = [text stringByAppendingString:@" "];
-    return [self.inputToolbar.contentView.textView.text jsq_stringByTrimingWhitespace];
+    // resign and become first responder to accept any auto-correct suggestions
+    if ([self.inputToolbar.contentView.textView isFirstResponder]) {
+        [self.inputToolbar.contentView.textView resignFirstResponder];
+        [self.inputToolbar.contentView.textView becomeFirstResponder];
+    }
+    return self.inputToolbar.contentView.textView.text;
 }
 
 #pragma mark - Text view delegate


### PR DESCRIPTION
The strategy of adding a space and then trimming it was causing an indefinite hang with some strange strings. Reproducible with a ridiculous example like:

```




ȗ̷͓͍̭͉̖͎̙̹̱͙̝̥̥̣͍͆͛͋ͨ̄̑́́̕n͋́̏͊̄̏̾̈́̀̔̓ͥ͑ͦ̆̔ͬ҉̢͉͓͖͕͔͎͎͙̹͘i̴̧̡̳̱̺̪̘̲͖̠̙̭̅ͮ̀́ͮͯ̀̾͂͊͒̎̚̚͡͝c̓̓̈͂͊̈́͛̃̃ͫ͂̇ͫͫͣͧ͗̚͏̜͈̥̳̜̖͔̥̕͜ͅo̸̧̯̤̺͓͇̭̮͕̜̫͈̲̫͇̫̊͑̊ͤͪͫͩͨ̀̕͝ͅd̸̲̯͇̲̻̣̼͚̳̖̗̣̫̭̼̼̞͈ͩ̈̃̈̅̚͘͝͞ė̇̌ͩ̔͋̏ͣͮͪͦ͌ͤ̾̒̋͑̕҉̛̮̲͈̱̥̲



```

(isn't unicode great?)

Anyway, resigning and becoming the first responder seems to be another accepted approach for accepting auto-correct, and it works to avoid this hang as well. Probably better than mucking with the string.
