### PR TITLE
more closely mimic iOS bubble size and font

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -117,6 +117,8 @@
     self.textView.contentInset = UIEdgeInsetsZero;
     self.textView.scrollIndicatorInsets = UIEdgeInsetsZero;
     self.textView.contentOffset = CGPointZero;
+    self.textView.textContainer.lineFragmentPadding = 0;
+    self.textView.textContainerInset = UIEdgeInsetsZero;
     self.textView.linkTextAttributes = @{ NSForegroundColorAttributeName : [UIColor whiteColor],
                                           NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle | NSUnderlinePatternSolid) };
     


### PR DESCRIPTION
This updates the bubble sizing to more closely mimic iOS. It also sets the font size to use Dynamic Type, like the native Message app does (I didn't implement runtime switching -- that can be done separately).

https://github.com/jessesquires/JSQMessagesViewController/issues/489
https://github.com/jessesquires/JSQMessagesViewController/issues/407
https://github.com/jessesquires/JSQMessagesViewController/issues/347
