### PR TITLE
Fix inset of messageBubbleTopLabel when there is no avatar

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -422,7 +422,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     
     cell.backgroundColor = [UIColor clearColor];
     
-    CGFloat bubbleTopLabelInset = 60.0f;
+    CGFloat bubbleTopLabelInset = cell.avatarImageView.image ? 60.0f : 15.0f;
     
     if (isOutgoingMessage) {
         cell.messageBubbleTopLabel.textInsets = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, bubbleTopLabelInset);


### PR DESCRIPTION
Inset for messageBubbleTopLabel when there are no avatars was producing an ugly layout:

![Before](http://i.imgur.com/k6IEzR3.png)

Now the layout is correct

![After](http://i.imgur.com/baYGLIX.png)
