### PR TITLE
Reset contraints in prepareForReuse

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -156,6 +156,10 @@
 {
     [super prepareForReuse];
     
+    self.cellTopLabelHeightConstraint.constant = 0.0f;
+    self.messageBubbleTopLabelHeightConstraint.constant = 0.0f;
+    self.cellBottomLabelHeightConstraint.constant = 0.0f;
+
     self.cellTopLabel.text = nil;
     self.messageBubbleTopLabel.text = nil;
     self.cellBottomLabel.text = nil;


### PR DESCRIPTION
It appears that when reusing a cell which did have a non-zero messageBubbleTopLabelHeightConstraint for a row which has zero for the messageBubbleTopLabelHeightConstraint, the OS complains about being unable to satisfy constraints.

To reproduce with the demo app:
1. Enter "ABC" (or any text probably) and "send" it.
2. Quickly tap the "receive" button 6+ times (without waiting for the animation to finish).

You should wind up with more than one received message from "Person 1" without a received message from "Person 2" in between, which results in a zero height top label. When you scroll, the zero height top label cell is reused by a 20-high label.

We need to reset the constraints in -[JSQMessagesCollectionViewCell prepareForReuse]
`self.cellTopLabelHeightConstraint.constant = 0.0f;`
`self.messageBubbleTopLabelHeightConstraint.constant = 0.0f;`
`self.cellBottomLabelHeightConstraint.constant = 0.0f;`

Debugger output:
`2014-10-06 14:43:38.680 JSQMessages[21613:2165594] Unable to simultaneously satisfy constraints.`
`Probably at least one of the constraints in the following list is one you don't want. Try this: (1) look at each constraint and try to figure out which you don't expect; (2) find the code that added the unwanted constraint or constraints and fix it. (Note: If you're seeing NSAutoresizingMaskLayoutConstraints that you don't understand, refer to the documentation for the UIView property translatesAutoresizingMaskIntoConstraints)`
`(`
`"<NSLayoutConstraint:0x7feaecf182d0 V:[JSQMessagesLabel:0x7feaec8bf740(20)]>",`
`"<NSLayoutConstraint:0x7feaec83a110 V:[JSQMessagesLabel:0x7feaecff86e0(20)]>",`
`"<NSLayoutConstraint:0x7feaecfa3190 V:[JSQMessagesLabel:0x7feaecff2300(0)]>",`
`"<NSLayoutConstraint:0x7feaecff1650 V:|-(0)-[JSQMessagesLabel:0x7feaec8bf740]   (Names: '|':UIView:0x7feaecfb0730 )>",`
`"<NSLayoutConstraint:0x7feaecf89020 V:[JSQMessagesLabel:0x7feaec8bf740]-(0)-[JSQMessagesLabel:0x7feaecff86e0]>",`
`"<NSLayoutConstraint:0x7feaecfe28d0 V:[JSQMessagesLabel:0x7feaecff86e0]-(0)-[UIView:0x7feaecf75170]>",`
`"<NSLayoutConstraint:0x7feaecff7cf0 V:[JSQMessagesLabel:0x7feaecff2300]-(0)-|   (Names: '|':UIView:0x7feaecfb0730 )>",`
`"<NSLayoutConstraint:0x7feaecfedd50 V:[UIView:0x7feaecf75170]-(0)-[JSQMessagesLabel:0x7feaecff2300]>",`
`"<NSAutoresizingMaskLayoutConstraint:0x7feaecf71970 h=--& v=--& V:[UIView:0x7feaecfb0730(38)]>"`
`)`

`Will attempt to recover by breaking constraint 
<NSLayoutCons
![screen shot 2014-10-06 at 2 48 13 pm](https://cloud.githubusercontent.com/assets/4912283/4534249/92f99296-4da3-11e4-8641-f90da8502be0.png)
traint:0x7feaec83a110 V:[JSQMessagesLabel:0x7feaecff86e0(20)]>`
