### PR TITLE
Import of 'JSQMessagesInputToolbar' instead of forward class declaration

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -20,8 +20,7 @@
 
 #import "JSQMessagesCollectionView.h"
 #import "JSQMessagesCollectionViewFlowLayout.h"
-
-@class JSQMessagesInputToolbar;
+#import "JSQMessagesInputToolbar.h"
 
 /**
  *  The `JSQMessagesViewController` class is an abstract class that represents a view controller whose content consists of


### PR DESCRIPTION
Since 'JSQMessagesViewController' is meant to be an abstract class, it should import all of its dependencies in the header so that subclasses don't have to import them.

I came across this when my subclass of 'JSQMessagesViewController' did not recognize "self.inputToolbar.contentView". 
I think that subclasses shouldn't have to import specific header files for the abstract base class.
