### PR TITLE
create UIDynamicAnimator only if springness is enabled

### DIFF
--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
@@ -219,7 +219,7 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
 
 - (UIDynamicAnimator *)dynamicAnimator
 {
-    if (!_dynamicAnimator) {
+    if (self.springinessEnabled && !_dynamicAnimator) {
         _dynamicAnimator = [[UIDynamicAnimator alloc] initWithCollectionViewLayout:self];
     }
     return _dynamicAnimator;


### PR DESCRIPTION
When `springinessEnabled` is setted to `NO`, app crashed on `-[UIDynamicAnimator dealloc]`, below is the stack trace.

```
Thread : Crashed: com.apple.main-thread
0  libobjc.A.dylib                0x03c47ecf lookUpImpOrForward + 61
1  libobjc.A.dylib                0x03c47e8d _class_lookupMethodAndLoadCache3 + 55
2  libobjc.A.dylib                0x03c5212f objc_msgSend + 139
3  UIKit                          0x0332307c -[UIDynamicAnimator dealloc] + 555
4  libobjc.A.dylib                0x03c53772 _ZN11objc_object17sidetable_releaseEb + 248
5  libobjc.A.dylib                0x03c52e9b objc_release + 43
6  libobjc.A.dylib                0x03c53d32 _ZN12_GLOBAL__N_119AutoreleasePoolPage3popEPv + 586
7  CoreFoundation                 0x04557c58 _CFAutoreleasePoolPop + 24
8  UIKit                          0x02a8342c _wrapRunLoopWithAutoreleasePoolHandler + 59
9  CoreFoundation                 0x04598fbe __CFRUNLOOP_IS_CALLING_OUT_TO_AN_OBSERVER_CALLBACK_FUNCTION__ + 30
10 CoreFoundation                 0x04598f00 __CFRunLoopDoObservers + 400
11 CoreFoundation                 0x0458e93a __CFRunLoopRun + 1226
12 CoreFoundation                 0x0458e1ab CFRunLoopRunSpecific + 443
13 CoreFoundation                 0x0458dfdb CFRunLoopRunInMode + 123
14 GraphicsServices               0x0626d24f GSEventRunModal + 192
15 GraphicsServices               0x0626d08c GSEventRun + 104
16 UIKit                          0x02a87e16 UIApplicationMain + 1526
17 Frodo                          0x0005f5cd main (main.m:16)
18 libdyld.dylib                  0x04b6eac9 start + 1
```
