### PR TITLE
Use custom Nib with JSQMessagesViewController subclass

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -179,6 +179,20 @@
 + (UINib *)nib;
 
 /**
+ *  Returns name of the `UINib` to load for `JSQMessagesViewController`.
+ *
+ *  @return An `NSString` representing he name of the `UINib` to load.
+ */
++ (NSString *)nibName;
+
+/**
+ *  Returns the `NSBundle` containing the `UINib` to load for `JSQMessagesViewController`.
+ *
+ *  @return An `NSBundle` to load the `UINib` from.
+ */
++ (NSBundle *)nibBundle;
+
+/**
  *  Creates and returns a new `JSQMessagesViewController` object.
  *  
  *  @discussion This is the designated initializer for programmatic instantiation.

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -105,6 +105,16 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
                           bundle:[NSBundle mainBundle]];
 }
 
++ (NSString *)nibName
+{
+  return NSStringFromClass([JSQMessagesViewController class]);
+}
+
++ (NSBundle *)nibBundle
+{
+  return [NSBundle mainBundle];
+}
+
 + (instancetype)messagesViewController
 {
     return [[[self class] alloc] initWithNibName:NSStringFromClass([JSQMessagesViewController class])
@@ -205,9 +215,9 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-    [[NSBundle mainBundle] loadNibNamed:NSStringFromClass([JSQMessagesViewController class])
-                                  owner:self
-                                options:nil];
+    [[[self class] nibBundle] loadNibNamed:[[self class] nibName]
+                                     owner:self
+                                   options:nil];
     [self jsq_configureMessagesViewController];
     [self jsq_registerForNotifications:YES];
 }


### PR DESCRIPTION
This allows a custom nib to be used with a subclass of JSQMessagesViewController,

By implementing the `nibName` and `nibBundle` class methods in the subclass, a user can load a custom nib.

I really needed to use this myself, and I'm hoping it is allowed into the main repository.

If you are not sure why anyone would need to do this, I'm using it to load a subclass of the input toolbar that has different logic for when the send button should be enabled. In my application, I want users to only be able to reply to messages that were sent to them by us, but not initiate a conversation on their own, so I'm disabling the send button if there are no messages in the chat.
