### PR TITLE
Rasterize collection view cell for scrolling performance

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -468,6 +468,9 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     
     cell.textView.dataDetectorTypes = UIDataDetectorTypeAll;
     
+    cell.layer.rasterizationScale = [UIScreen mainScreen].scale;
+    cell.layer.shouldRasterize = YES;
+    
     return cell;
 }
 


### PR DESCRIPTION
It seems a bit minimalistic, but these two lines do notably improve scrolling performance on iOS8 (see issue https://github.com/jessesquires/JSQMessagesViewController/issues/492).

As discussed with @FredericJacobs (issue : https://github.com/WhisperSystems/Signal-iOS/issues/175), we can rasterise JSQMessagesCollectionView cells' layer. If the `shouldRasterize` flag is set to `YES`, ["the layer is rendered as a bitmap in its local coordinate space and then composited to the destination with any other content."](https://developer.apple.com/library/mac/documentation/GraphicsImaging/Reference/CALayer_class/index.html#//apple_ref/occ/instp/CALayer/shouldRasterize). This allows for the scroll view to scroll smoothly without worrying about redrawing the cells all the time.

See also : SO tickets [1](https://stackoverflow.com/questions/16336772/uicollectionview-performance-updatevisiblecellsnow)  [2](https://stackoverflow.com/questions/12898259/uiscrollview-performance-tips)
