### PR TITLE
Fix #645: add 'keyboardDidHide' notification handling

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.h
@@ -59,6 +59,15 @@ FOUNDATION_EXPORT NSString * const JSQMessagesKeyboardControllerUserInfoKeyKeybo
  */
 - (void)keyboardController:(JSQMessagesKeyboardController *)keyboardController keyboardDidChangeFrame:(CGRect)keyboardFrame;
 
+@optional
+
+/**
+ *  Tells the delegate that the keyboard has been hidden.
+ *
+ *  @param keyboardController The keyboard controller that is notifying the delegate.
+ */
+- (void)keyboardControllerDidReceiveKeyboardHideNotification:(JSQMessagesKeyboardController *)keyboardController;
+
 @end
 
 

--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -212,6 +212,11 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
     
     [self jsq_handleKeyboardNotification:notification completion:^(BOOL finished) {
         [self.panGestureRecognizer removeTarget:self action:NULL];
+        
+        if ([self.delegate respondsToSelector:@selector(keyboardControllerDidReceiveKeyboardHideNotification:)]) {
+            [self.delegate keyboardControllerDidReceiveKeyboardHideNotification:self];
+        }
+        
     }];
 }
 

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -760,6 +760,13 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     heightFromBottom = MAX(0.0f, heightFromBottom);
     
     [self jsq_setToolbarBottomLayoutGuideConstant:heightFromBottom];
+
+}
+
+- (void)keyboardControllerDidReceiveKeyboardHideNotification:(JSQMessagesKeyboardController *)keyboardController {
+    
+    [self jsq_setToolbarBottomLayoutGuideConstant:0.0f];
+    
 }
 
 - (void)jsq_setToolbarBottomLayoutGuideConstant:(CGFloat)constant


### PR DESCRIPTION
fixes #645, and possibly related issues

:: JSQMessagesKeyboardControllerDelegate protocol adds optional `keyboardControllerDidReceiveKeyboardHideNotification:` method
:: this method is called within the completion block of the typical keyboard frame change notification handler, ensuring that the 'hide' message is received last
:: `JSQMessagesViewController` uses this delegate callback to call `jsq_setToolbarBottomLayoutGuideConstant:` with a value of `0.0f` (ensuring that a 'hidden' keyboard results in a 0-position input toolbar)
