### PR TITLE
Fix #648: Verify that `inputToolbar` `isFirstResponder` before responding to `UIKeyboard` notifications

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -755,7 +755,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (void)keyboardController:(JSQMessagesKeyboardController *)keyboardController keyboardDidChangeFrame:(CGRect)keyboardFrame
 {
-    if ([self.inputToolbar.contentView.textView isFirstResponder]) {
+    if ([self.inputToolbar.contentView.textView isFirstResponder] || self.toolbarBottomLayoutGuide.constant != 0) {
         CGFloat heightFromBottom = CGRectGetMaxY(self.collectionView.frame) - CGRectGetMinY(keyboardFrame);
         
         heightFromBottom = MAX(0.0f, heightFromBottom);


### PR DESCRIPTION
This PR fixes #648 by checking verifying that the `inputToolbar` `textView` `isFirstResponder` - OR whether it is already 'in motion', i.e. in the process of being hidden AFTER it `resignFirstResponder` is called.

**NOTE:** The changes introduced in #646 will also need this fix - i.e. the same conditional must be applied to the 'keyboard did hide' notification handler.
