### PR TITLE
Making JSQMessagesInputToolbar easier to subclass

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -122,7 +122,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     
     self.jsq_isObserving = NO;
     
-    self.toolbarHeightConstraint.constant = kJSQMessagesInputToolbarHeightDefault;
+    self.toolbarHeightConstraint.constant = [self.inputToolbar inputToolbarHeightDefault];
     
     self.collectionView.dataSource = self;
     self.collectionView.delegate = self;
@@ -901,8 +901,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 {
     self.toolbarHeightConstraint.constant += dy;
     
-    if (self.toolbarHeightConstraint.constant < kJSQMessagesInputToolbarHeightDefault) {
-        self.toolbarHeightConstraint.constant = kJSQMessagesInputToolbarHeightDefault;
+    if (self.toolbarHeightConstraint.constant < [self.inputToolbar inputToolbarHeightDefault]) {
+        self.toolbarHeightConstraint.constant = [self.inputToolbar inputToolbarHeightDefault];
     }
     
     [self.view setNeedsUpdateConstraints];

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
@@ -24,11 +24,6 @@
 #import "JSQMessagesToolbarContentView.h"
 
 /**
- *  A constant the specifies the default height for a `JSQMessagesInputToolbar`.
- */
-FOUNDATION_EXPORT const CGFloat kJSQMessagesInputToolbarHeightDefault;
-
-/**
  *  The `JSQMessagesInputToolbarDelegate` protocol defines methods for interacting with
  *  a `JSQMessagesInputToolbar` object.
  */
@@ -92,5 +87,10 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesInputToolbarHeightDefault;
  *  That is, the send button will be enabled if there is text in the `textView`, and disabled otherwise.
  */
 - (void)toggleSendButtonEnabled;
+
+/**
+ *	A CGFloat value specifies the default height for this toolbar.
+ */
+- (CGFloat)inputToolbarHeightDefault;
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
@@ -47,6 +47,17 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
 
 @implementation JSQMessagesInputToolbar
 
+- (JSQMessagesToolbarContentView *)loadContentView {
+	NSArray *nibViews = [[NSBundle bundleForClass:[self class]] loadNibNamed:NSStringFromClass([JSQMessagesToolbarContentView class])
+																	   owner:nil
+																	 options:nil];
+	return	[nibViews firstObject];
+}
+
+- (CGFloat)inputToolbarHeightDefault {
+	return kJSQMessagesInputToolbarHeightDefault;
+}
+
 #pragma mark - Initialization
 
 - (void)awakeFromNib
@@ -57,10 +68,7 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
     self.jsq_isObserving = NO;
     self.sendButtonOnRight = YES;
     
-    NSArray *nibViews = [[NSBundle bundleForClass:[self class]] loadNibNamed:NSStringFromClass([JSQMessagesToolbarContentView class])
-                                                                       owner:nil
-                                                                     options:nil];
-    JSQMessagesToolbarContentView *toolbarContentView = [nibViews firstObject];
+	JSQMessagesToolbarContentView *toolbarContentView = [self loadContentView];
     toolbarContentView.frame = self.frame;
     [self addSubview:toolbarContentView];
     [self jsq_pinAllEdgesOfSubview:toolbarContentView];

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
@@ -47,17 +47,6 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
 
 @implementation JSQMessagesInputToolbar
 
-- (JSQMessagesToolbarContentView *)loadContentView {
-	NSArray *nibViews = [[NSBundle bundleForClass:[self class]] loadNibNamed:NSStringFromClass([JSQMessagesToolbarContentView class])
-																	   owner:nil
-																	 options:nil];
-	return	[nibViews firstObject];
-}
-
-- (CGFloat)inputToolbarHeightDefault {
-	return kJSQMessagesInputToolbarHeightDefault;
-}
-
 #pragma mark - Initialization
 
 - (void)awakeFromNib
@@ -185,6 +174,19 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
     @catch (NSException *__unused exception) { }
     
     _jsq_isObserving = NO;
+}
+
+#pragma mark - Subclassing
+
+- (CGFloat)inputToolbarHeightDefault {
+	return kJSQMessagesInputToolbarHeightDefault;
+}
+
+- (JSQMessagesToolbarContentView *)loadContentView {
+	NSArray *nibViews = [[NSBundle bundleForClass:[self class]] loadNibNamed:NSStringFromClass([JSQMessagesToolbarContentView class])
+																	   owner:nil
+																	 options:nil];
+	return	[nibViews firstObject];
 }
 
 @end


### PR DESCRIPTION
@jessesquires 

Here is the diff that allows JSQMessagesInputToolbar to be subclasses by clients of your excellent library.
This is what I was (clumsily) describing in issue #750 

Pretty much nothing has changed from the library's perspective, but these two changes make it possible for clients to subclass the input toolbar.

I hope you'll consider taking this pull request.
Thank you
Ray
