### PR TITLE
Moving to TTTAttributedString

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.h
@@ -24,10 +24,14 @@
  *  in a `JSQMessagesCollectionViewCell`.
  */
 
+
 @interface JSQMessagesCellTextView : TTTAttributedLabel
+- (NSTextCheckingResult *)linkAtPoint:(CGPoint)point;
 
 @property (nonatomic) NSDictionary* linkTextAttributes;
 @property (nonatomic) BOOL selectable;
 @property (nonatomic) UIEdgeInsets textContainerInset;
+@property (nonatomic, strong, readonly) UITapGestureRecognizer *tapGestureRecognizer;
+
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.h
@@ -26,11 +26,8 @@
 
 @interface JSQMessagesCellTextView : TTTAttributedLabel
 
-- (NSDictionary *) linkTextAttributes;
-- (void) setLinkTextAttributes:(NSDictionary *)attributes;
-- (UIEdgeInsets) textContainerInset;
-- (void) setTextContainerInset:(UIEdgeInsets)textInsets;
-- (BOOL) selectable;
-- (void) setSelectable:(BOOL *)makeSelectable;
+@property (atomic, readwrite) NSDictionary* linkTextAttributes;
+@property (atomic, readwrite) BOOL selectable;
+@property (atomic, readwrite) UIEdgeInsets textContainerInset;
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.h
@@ -26,8 +26,8 @@
 
 @interface JSQMessagesCellTextView : TTTAttributedLabel
 
-@property (atomic, readwrite) NSDictionary* linkTextAttributes;
-@property (atomic, readwrite) BOOL selectable;
-@property (atomic, readwrite) UIEdgeInsets textContainerInset;
+@property (nonatomic) NSDictionary* linkTextAttributes;
+@property (nonatomic) BOOL selectable;
+@property (nonatomic) UIEdgeInsets textContainerInset;
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.h
@@ -17,11 +17,20 @@
 //
 
 #import <UIKit/UIKit.h>
+#import "TTTAttributedLabel.h"
 
 /**
- *  `JSQMessagesCellTextView` is a subclass of `UITextView` that is used to display text
+ *  `JSQMessagesCellTextView` is a subclass of `TTTAttributedLabel` that is used to display text
  *  in a `JSQMessagesCollectionViewCell`.
  */
-@interface JSQMessagesCellTextView : UITextView
+
+@interface JSQMessagesCellTextView : TTTAttributedLabel
+
+- (NSDictionary *) linkTextAttributes;
+- (void) setLinkTextAttributes:(NSDictionary *)attributes;
+- (UIEdgeInsets) textContainerInset;
+- (void) setTextContainerInset:(UIEdgeInsets)textInsets;
+- (BOOL) selectable;
+- (void) setSelectable:(BOOL *)makeSelectable;
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
@@ -64,8 +64,12 @@
 
 - (void)setTextColor:(UIColor *)textColor {
     [super setTextColor:textColor];
-    // Resets the text with new attributes
+    // Resets the ttt text with new attributes
     self.text = self.text;
+}
+
+- (NSDictionary *)linkTextAttributes {
+    return self.linkAttributes;
 }
 
 - (void)setLinkTextAttributes:(id)attributes {
@@ -84,8 +88,8 @@
     return self.userInteractionEnabled;
 }
 
-- (void) setSelectable:(BOOL *) makeSelectable {
-    [self setUserInteractionEnabled:makeSelectable];
+- (void) setSelectable:(BOOL) makeSelectable {
+    [self setUserInteractionEnabled: makeSelectable];
 }
 
 

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
@@ -34,6 +34,9 @@
     self.activeLinkAttributes = @{ NSForegroundColorAttributeName : [UIColor whiteColor],
                                  NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle | NSUnderlinePatternSolid) };
     [self removeGestureRecognizer:super.longPressGestureRecognizer];
+    _tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(tappingFired:)];
+    _tapGestureRecognizer.delegate = self;
+    [self addGestureRecognizer:_tapGestureRecognizer];
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
@@ -92,5 +95,57 @@
     [self setUserInteractionEnabled: makeSelectable];
 }
 
+- (void) tappingFired:(UITapGestureRecognizer *)sender {
+    switch (sender.state) {
+        case UIGestureRecognizerStateEnded: {
+            CGPoint touchPoint = [sender locationInView:self];
+            NSTextCheckingResult *result = [self linkAtPoint:touchPoint];
+            if (result){
+                switch (result.resultType) {
+                    case NSTextCheckingTypeLink:
+                        if([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithURL:)]) {
+                            [self.delegate attributedLabel:self didSelectLinkWithURL:result.URL];
+                            return;
+                        }
+                        break;
+                    case NSTextCheckingTypeAddress:
+                        if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithAddress:)]) {
+                            [self.delegate attributedLabel:self didSelectLinkWithAddress:result.addressComponents];
+                            return;
+                        }
+                        break;
+                    case NSTextCheckingTypePhoneNumber:
+                        if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithPhoneNumber:)]) {
+                            [self.delegate attributedLabel:self didSelectLinkWithPhoneNumber:result.phoneNumber];
+                            return;
+                        }
+                        break;
+                    case NSTextCheckingTypeDate:
+                        if (result.timeZone && [self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:timeZone:duration:)]) {
+                            [self.delegate attributedLabel:self didSelectLinkWithDate:result.date timeZone:result.timeZone duration:result.duration];
+                            return;
+                        } else if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithDate:)]) {
+                            [self.delegate attributedLabel:self didSelectLinkWithDate:result.date];
+                            return;
+                        }
+                        break;
+                    case NSTextCheckingTypeTransitInformation:
+                        if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTransitInformation:)]) {
+                            [self.delegate attributedLabel:self didSelectLinkWithTransitInformation:result.components];
+                            return;
+                        }
+                    default:
+                        break;
+                }
+                if ([self.delegate respondsToSelector:@selector(attributedLabel:didSelectLinkWithTextCheckingResult:)]){
+                    [self.delegate attributedLabel:self didSelectLinkWithTextCheckingResult:result];
+                }
+            }
+            break;
+        }
+        default:
+            break;
+    }
+}
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
@@ -25,27 +25,15 @@
     [super awakeFromNib];
     
     self.textColor = [UIColor whiteColor];
-    self.editable = NO;
-    self.selectable = YES;
+    [self setUserInteractionEnabled:YES];
     self.userInteractionEnabled = YES;
-    self.dataDetectorTypes = UIDataDetectorTypeNone;
-    self.showsHorizontalScrollIndicator = NO;
-    self.showsVerticalScrollIndicator = NO;
-    self.scrollEnabled = NO;
+    self.enabledTextCheckingTypes = UIDataDetectorTypeNone;
     self.backgroundColor = [UIColor clearColor];
-    self.contentInset = UIEdgeInsetsZero;
-    self.scrollIndicatorInsets = UIEdgeInsetsZero;
-    self.contentOffset = CGPointZero;
-    self.textContainerInset = UIEdgeInsetsZero;
-    self.textContainer.lineFragmentPadding = 0;
-    self.linkTextAttributes = @{ NSForegroundColorAttributeName : [UIColor whiteColor],
+    self.textInsets = UIEdgeInsetsZero;
+    self.numberOfLines = 0;
+    self.activeLinkAttributes = @{ NSForegroundColorAttributeName : [UIColor whiteColor],
                                  NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle | NSUnderlinePatternSolid) };
-}
-
-- (void)setSelectedRange:(NSRange)selectedRange
-{
-    //  prevent selecting text
-    [super setSelectedRange:NSMakeRange(NSNotFound, 0)];
+    [self removeGestureRecognizer:super.longPressGestureRecognizer];
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
@@ -73,5 +61,32 @@
     
     return YES;
 }
+
+- (void)setTextColor:(UIColor *)textColor {
+    [super setTextColor:textColor];
+    // Resets the text with new attributes
+    self.text = self.text;
+}
+
+- (void)setLinkTextAttributes:(id)attributes {
+    self.linkAttributes = attributes;
+}
+
+- (UIEdgeInsets)textContainerInset {
+    return self.textInsets;
+}
+
+- (void)setTextContainerInset:(UIEdgeInsets)textInsets {
+    self.textInsets = textInsets;
+}
+
+- (BOOL) selectable {
+    return self.userInteractionEnabled;
+}
+
+- (void) setSelectable:(BOOL *) makeSelectable {
+    [self setUserInteractionEnabled:makeSelectable];
+}
+
 
 @end

--- a/Podfile
+++ b/Podfile
@@ -6,6 +6,7 @@ platform :ios, '7.0'
 inhibit_all_warnings!
 
 pod 'JSQSystemSoundPlayer'
+pod 'TTTAttributedLabel'
 
 target :JSQMessagesTests, :exclusive => true do
     pod 'OCMock'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,13 +1,16 @@
 PODS:
   - JSQSystemSoundPlayer (2.0.1)
   - OCMock (3.1.2)
+  - TTTAttributedLabel (1.13.1)
 
 DEPENDENCIES:
   - JSQSystemSoundPlayer
   - OCMock
+  - TTTAttributedLabel
 
 SPEC CHECKSUMS:
   JSQSystemSoundPlayer: 55528c699a283aae2220d3ae7b8b527d2ecef4b4
   OCMock: ecdd510b73ef397f2f97274785c1e87fd147c49f
+  TTTAttributedLabel: 71843ac4178e1ebd6b0950b54325146726a124ae
 
 COCOAPODS: 0.35.0


### PR DESCRIPTION
Hi Jesse,

Initially I started this fork to support custom data detectors to make clickable hashtags and @ mentions. However, I noticed others' request for TTTAttributedString in places like #492. For the time being, I was able to contain the changes within JSQMessagesCellTextView, and as is, this won't break anything in the Demo app. 

Let me know what you think; if this is a good starting point, would be happy to work on this to create something we can pull into JSQMessagesViewController. 

Cheers,
Sebastian