### PR TITLE
Changed sendButtonOnRight to sendButtonLocation

### DIFF
--- a/JSQMessagesTests/ViewTests/JSQMessagesInputToolbarTests.m
+++ b/JSQMessagesTests/ViewTests/JSQMessagesInputToolbarTests.m
@@ -39,7 +39,7 @@
     JSQMessagesInputToolbar *toolbar = vc.inputToolbar;
     XCTAssertNotNil(toolbar, @"Toolbar should not be nil");
     XCTAssertNotNil(toolbar.contentView, @"Toolbar content view should not be nil");
-    XCTAssertEqual(toolbar.sendButtonOnRight, YES, @"Property should be equal to default value");
+    XCTAssertEqual(toolbar.sendButtonLocation, JSQMessagesInputSendButtonLocationRight, @"Property should be equal to default value");
 }
 
 // TODO: investigate this later

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -732,21 +732,21 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
 
 - (void)messagesInputToolbar:(JSQMessagesInputToolbar *)toolbar didPressLeftBarButton:(UIButton *)sender
 {
-    if (toolbar.sendButtonOnRight) {
-        [self didPressAccessoryButton:sender];
-    }
-    else {
+    if (toolbar.sendButtonLocation == JSQMessagesInputSendButtonLocationLeft) {
         [self didPressSendButton:sender
                  withMessageText:[self jsq_currentlyComposedMessageText]
                         senderId:[self.collectionView.dataSource senderId]
                senderDisplayName:[self.collectionView.dataSource senderDisplayName]
                             date:[NSDate date]];
     }
+    else {
+        [self didPressAccessoryButton:sender];
+    }
 }
 
 - (void)messagesInputToolbar:(JSQMessagesInputToolbar *)toolbar didPressRightBarButton:(UIButton *)sender
 {
-    if (toolbar.sendButtonOnRight) {
+    if (toolbar.sendButtonLocation == JSQMessagesInputSendButtonLocationRight) {
         [self didPressSendButton:sender
                  withMessageText:[self jsq_currentlyComposedMessageText]
                         senderId:[self.collectionView.dataSource senderId]

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
@@ -25,6 +25,13 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef NS_ENUM(NSUInteger, JSQMessagesInputSendButtonLocation) {
+    JSQMessagesInputSendButtonLocationNone,
+    JSQMessagesInputSendButtonLocationRight,
+    JSQMessagesInputSendButtonLocationLeft
+};
+
+
 /**
  *  The `JSQMessagesInputToolbarDelegate` protocol defines methods for interacting with
  *  a `JSQMessagesInputToolbar` object.
@@ -71,17 +78,17 @@ NS_ASSUME_NONNULL_BEGIN
 @property (weak, nonatomic, readonly, nullable) JSQMessagesToolbarContentView *contentView;
 
 /**
- *  A boolean value indicating whether the send button is on the right side of the toolbar or not.
- *
- *  @discussion The default value is `YES`, which indicates that the send button is the right-most subview of
- *  the toolbar's `contentView`. Set to `NO` to specify that the send button is on the left. This
+ *  An enum value indicating the location of thee send button in relation to the toolbar.
+ *  
+ *  @discussion The default value is `JSQMessagesInputSendButtonLocationRight`, which indicates that the send button is the right-most subview of
+ *  the toolbar's `contentView`. Set to `JSQMessagesInputSendButtonLocationLeft` to specify that the send button is on the left. Set to 'JSQMessagesInputSendButtonLocationNone' if there is no send button or if you want to take control of the send button actions. This
  *  property is used to determine which touch events correspond to which actions.
  *
  *  @warning Note, this property *does not* change the positions of buttons in the toolbar's content view.
- *  It only specifies whether the `rightBarButtonItem `or the `leftBarButtonItem` is the send button.
+ *  It only specifies whether the `rightBarButtonItem `or the `leftBarButtonItem` is the send button or there is no send button.
  *  The other button then acts as the accessory button.
  */
-@property (assign, nonatomic) BOOL sendButtonOnRight;
+@property (assign, nonatomic) JSQMessagesInputSendButtonLocation sendButtonLocation;
 
 /**
  *  Specify if the send button should be enabled automatically when the `textView` contains text.

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
@@ -48,8 +48,9 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
     [super awakeFromNib];
     self.backgroundColor = [UIColor whiteColor];
     self.jsq_isObserving = NO;
-    self.sendButtonOnRight = YES;
-    self.enablesSendButtonAutomatically = YES;
+    self.sendButtonLocation = JSQMessagesInputSendButtonLocationRight;
+	self.enablesSendButtonAutomatically = YES;
+
 
     self.preferredDefaultHeight = 44.0f;
     self.maximumHeight = NSNotFound;
@@ -122,13 +123,17 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
     if (!self.enablesSendButtonAutomatically) {
         return;
     }
-
+    
     BOOL enabled = [self.contentView.textView hasText];
-    if (self.sendButtonOnRight) {
-        self.contentView.rightBarButtonItem.enabled = enabled;
-    }
-    else {
-        self.contentView.leftBarButtonItem.enabled = enabled;
+    switch (self.sendButtonLocation) {
+        case JSQMessagesInputSendButtonLocationRight:
+            self.contentView.rightBarButtonItem.enabled = enabled;
+            break;
+        case JSQMessagesInputSendButtonLocationLeft:
+            self.contentView.leftBarButtonItem.enabled = enabled;
+            break;
+        default:
+            break;
     }
 }
 


### PR DESCRIPTION
Changed from BOOL to enum to make it easier to manipulate the behavior of the send and accessory button. This should make it easier to recreate behavior similar to messages.app where the microphone button replaces the send button when there is no text.

Currently to create two accessory buttons one on each side of the textview you have to constantly fight  ```- (void)toggleSendButtonEnabled``` . 
This changes it so you can basically turn off  ```- (void)toggleSendButtonEnabled```  and control whether the right and left buttons are enabled.