### PR TITLE
Create a Private header

### DIFF
--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -122,6 +122,7 @@
 		223FBACE0F24ADEF8B7F3F24 /* Pods-JSQMessagesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.debug.xcconfig"; sourceTree = "<group>"; };
 		27B7FD1B722B36B26CB3460B /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		782026E9E518622532ED474D /* libPods-JSQMessagesTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JSQMessagesTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		794739641AC1278500C7D69F /* JSQMessagesViewController+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "JSQMessagesViewController+Private.h"; sourceTree = "<group>"; };
 		88078A9B19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesMediaPlaceholderView.h; sourceTree = "<group>"; };
 		88078A9C19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaPlaceholderView.m; sourceTree = "<group>"; };
 		88324C3319F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaViewBubbleImageMaskerTests.m; sourceTree = "<group>"; };
@@ -467,6 +468,7 @@
 				88A25F6219D8E01A00924534 /* JSQMessagesViewController.h */,
 				88A25F6319D8E01A00924534 /* JSQMessagesViewController.m */,
 				88A25F6419D8E01A00924534 /* JSQMessagesViewController.xib */,
+				794739641AC1278500C7D69F /* JSQMessagesViewController+Private.h */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController+Private.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController+Private.h
@@ -1,0 +1,36 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2015 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import "JSQMessagesViewController.h"
+
+@interface JSQMessagesViewController ()
+
+/**
+ *
+ * This private method is how the View Controller initializes most of its initial state.
+ * If you override this method, you should probably call super as well.
+ */
+- (void)jsq_configureMessagesViewController;
+
+/**
+ *
+ * This private method is how the View Controller initializes the inputToolbar.
+ * If you override this method, you should probably call super as well.
+ */
+- (void)jsq_configureMessagesInputToolbar;
+@end

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -16,7 +16,7 @@
 //  Released under an MIT license: http://opensource.org/licenses/MIT
 //
 
-#import "JSQMessagesViewController.h"
+#import "JSQMessagesViewController+Private.h"
 
 #import "JSQMessagesKeyboardController.h"
 
@@ -63,8 +63,6 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 @property (assign, nonatomic) BOOL jsq_isObserving;
 
 @property (strong, nonatomic) NSIndexPath *selectedIndexPathForMenu;
-
-- (void)jsq_configureMessagesViewController;
 
 - (NSString *)jsq_currentlyComposedMessageText;
 
@@ -122,14 +120,10 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     
     self.jsq_isObserving = NO;
     
-    self.toolbarHeightConstraint.constant = self.inputToolbar.preferredDefaultHeight;
-    
     self.collectionView.dataSource = self;
     self.collectionView.delegate = self;
     
-    self.inputToolbar.delegate = self;
-    self.inputToolbar.contentView.textView.placeHolder = NSLocalizedStringFromTable(@"New Message", @"JSQMessages", @"Placeholder text for the message input text view");
-    self.inputToolbar.contentView.textView.delegate = self;
+	[self jsq_configureMessagesInputToolbar];
 
     self.automaticallyScrollsToMostRecentMessage = YES;
     
@@ -151,6 +145,14 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
                                                                           contextView:self.view
                                                                  panGestureRecognizer:self.collectionView.panGestureRecognizer
                                                                              delegate:self];
+}
+
+- (void)jsq_configureMessagesInputToolbar
+{
+	self.toolbarHeightConstraint.constant = self.inputToolbar.preferredDefaultHeight;
+	self.inputToolbar.delegate = self;
+	self.inputToolbar.contentView.textView.placeHolder = NSLocalizedStringFromTable(@"New Message", @"JSQMessages", @"Placeholder text for the message input text view");
+	self.inputToolbar.contentView.textView.delegate = self;
 }
 
 - (void)dealloc


### PR DESCRIPTION
declare our init method in a private header, so subclasses can gain access
Also, break the initialization into a couple pieces, so it will be easier for subclasses to modify the toolbar piece