### PR TITLE
Implement #693: Copy JSQMessageMediaData + tests

### DIFF
--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F0EFE0F1AC23D7E003FF3DB /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F0EFE0E1AC23D7E003FF3DB /* MobileCoreServices.framework */; };
+		1F0EFE111AC24AAF003FF3DB /* JSQMessageMediaData.m in Sources */ = {isa = PBXBuildFile; fileRef = 1F0EFE101AC24AAF003FF3DB /* JSQMessageMediaData.m */; };
 		36CF33BD29CF36EB06D0CCFD /* libPods-JSQMessagesTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 782026E9E518622532ED474D /* libPods-JSQMessagesTests.a */; };
 		77CC17A895E6E12BC9CB549A /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97E6750B77E8A7042BA0754B /* libPods.a */; };
 		88078A9D19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 88078A9C19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m */; };
@@ -120,6 +122,8 @@
 
 /* Begin PBXFileReference section */
 		0844AD596023C7658D39E241 /* Pods-JSQMessagesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.release.xcconfig"; sourceTree = "<group>"; };
+		1F0EFE0E1AC23D7E003FF3DB /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		1F0EFE101AC24AAF003FF3DB /* JSQMessageMediaData.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessageMediaData.m; sourceTree = "<group>"; };
 		223FBACE0F24ADEF8B7F3F24 /* Pods-JSQMessagesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.debug.xcconfig"; sourceTree = "<group>"; };
 		27B7FD1B722B36B26CB3460B /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		782026E9E518622532ED474D /* libPods-JSQMessagesTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JSQMessagesTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -274,6 +278,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F0EFE0F1AC23D7E003FF3DB /* MobileCoreServices.framework in Frameworks */,
 				88445B4419E1B5110014F889 /* MapKit.framework in Frameworks */,
 				88445B4219E1B50B0014F889 /* CoreLocation.framework in Frameworks */,
 				88445B3719E0AE5C0014F889 /* QuartzCore.framework in Frameworks */,
@@ -317,6 +322,7 @@
 		636A8663AEEE5C37B65C515D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1F0EFE0E1AC23D7E003FF3DB /* MobileCoreServices.framework */,
 				88445B3419E0AE4A0014F889 /* CoreGraphics.framework */,
 				88445B4119E1B50B0014F889 /* CoreLocation.framework */,
 				88445B3219E0AE450014F889 /* Foundation.framework */,
@@ -496,6 +502,7 @@
 				88A25F7C19D8E01A00924534 /* JSQMessageBubbleImageDataSource.h */,
 				88A25F7D19D8E01A00924534 /* JSQMessageData.h */,
 				88A25F7E19D8E01A00924534 /* JSQMessageMediaData.h */,
+				1F0EFE101AC24AAF003FF3DB /* JSQMessageMediaData.m */,
 				88A25F7F19D8E01A00924534 /* JSQMessagesAvatarImage.h */,
 				88A25F8019D8E01A00924534 /* JSQMessagesAvatarImage.m */,
 				88A25F8119D8E01A00924534 /* JSQMessagesBubbleImage.h */,
@@ -834,6 +841,7 @@
 				886FFD2E19E9A65D00EB8485 /* UIDevice+JSQMessages.m in Sources */,
 				88A25FB619D8E01A00924534 /* NSString+JSQMessages.m in Sources */,
 				88A901B619F618B100F99777 /* JSQMediaItem.m in Sources */,
+				1F0EFE111AC24AAF003FF3DB /* JSQMessageMediaData.m in Sources */,
 				88A25FCC19D8E01A00924534 /* JSQMessagesCollectionViewCellIncoming.m in Sources */,
 				88A25FBE19D8E01A00924534 /* JSQMessagesBubbleImageFactory.m in Sources */,
 				88A25FDF19D8E0C400924534 /* DemoMessagesViewController.m in Sources */,

--- a/JSQMessagesTests/ModelTests/JSQLocationMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQLocationMediaItemTests.m
@@ -12,6 +12,7 @@
 
 #import "JSQLocationMediaItem.h"
 
+#import <MobileCoreServices/UTCoreTypes.h>
 
 @interface JSQLocationMediaItemTests : XCTestCase
 
@@ -59,6 +60,20 @@
     }];
     
     XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+}
+
+- (void)testCopyableItemInMediaProtocol {
+    JSQLocationMediaItem *item = [[JSQLocationMediaItem alloc] initWithLocation:self.location];
+    XCTAssertNotNil(item);
+    XCTAssertNotNil([item copyableMediaItem]);
+    
+    NSDictionary *copyableMediaItem = [item copyableMediaItem];
+    XCTAssertNotNil(copyableMediaItem[JSQPasteboardUTTypeKey]);
+    XCTAssertEqualObjects((NSString *)kUTTypeURL, copyableMediaItem[JSQPasteboardUTTypeKey]);
+    
+    XCTAssertNotNil(copyableMediaItem[JSQPasteboardDataKey]);
+    NSURL *locationURL = [[NSURL alloc] initWithString:@"http://maps.google.com/maps?z=12&t=m&q=loc:37.795313+-122.393757"];
+    XCTAssertEqualObjects(locationURL, copyableMediaItem[JSQPasteboardDataKey]);
 }
 
 @end

--- a/JSQMessagesTests/ModelTests/JSQPhotoMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQPhotoMediaItemTests.m
@@ -12,6 +12,7 @@
 
 #import "JSQPhotoMediaItem.h"
 
+#import <MobileCoreServices/UTCoreTypes.h>
 
 @interface JSQPhotoMediaItemTests : XCTestCase
 
@@ -71,6 +72,20 @@
     item.image = [UIImage imageNamed:@"demo_avatar_jobs"];
     
     XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+}
+
+- (void)testCopyableItemInMediaProtocol {
+    JSQPhotoMediaItem *item = [[JSQPhotoMediaItem alloc] initWithImage:[UIImage imageNamed:@"demo_avatar_jobs"]];
+    XCTAssertNotNil(item);
+    XCTAssertNotNil([item copyableMediaItem]);
+    
+    NSDictionary *copyableMediaItem = [item copyableMediaItem];
+    XCTAssertNotNil(copyableMediaItem[JSQPasteboardUTTypeKey]);
+    XCTAssertEqualObjects((NSString *)kUTTypeJPEG, copyableMediaItem[JSQPasteboardUTTypeKey]);
+    
+    XCTAssertNotNil(copyableMediaItem[JSQPasteboardDataKey]);
+    UIImage *itemImage = [[UIImage alloc] initWithData:copyableMediaItem[JSQPasteboardDataKey]];
+    XCTAssertNotNil(itemImage);
 }
 
 @end

--- a/JSQMessagesViewController.podspec
+++ b/JSQMessagesViewController.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
 
 	s.resources = ['JSQMessagesViewController/Assets/JSQMessagesAssets.bundle', 'JSQMessagesViewController/**/*.{xib}']
 	
-	s.frameworks = 'QuartzCore', 'CoreGraphics', 'CoreLocation', 'MapKit', 'UIKit', 'Foundation'
+	s.frameworks = 'QuartzCore', 'CoreGraphics', 'CoreLocation', 'MapKit', 'UIKit', 'Foundation', 'MobileCoreServices'
 	s.requires_arc = true
 
 	s.dependency 'JSQSystemSoundPlayer', '~> 2.0.1'

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -21,6 +21,8 @@
 #import "JSQMessagesMediaPlaceholderView.h"
 #import "JSQMessagesMediaViewBubbleImageMasker.h"
 
+#import <MobileCoreServices/UTCoreTypes.h>
+
 
 @interface JSQLocationMediaItem ()
 
@@ -158,6 +160,15 @@
 - (NSUInteger)mediaHash
 {
     return self.hash;
+}
+
+- (NSDictionary *)copyableMediaItem {
+    // NSString *locationAsAppleMapsString = [NSString stringWithFormat:@"http://maps.apple.com/?ll=%f,%f", self.coordinate.latitude, self.coordinate.longitude];
+    NSString *locationAsGoogleMapsString = [NSString stringWithFormat:@"http://maps.google.com/maps?z=12&t=m&q=loc:%f+%f", self.coordinate.latitude, self.coordinate.longitude ];
+    NSURL *locationURL = [[NSURL alloc] initWithString:locationAsGoogleMapsString];
+    NSDictionary *copyableData = @{ JSQPasteboardUTTypeKey: (NSString *)kUTTypeURL, JSQPasteboardDataKey: locationURL };
+    
+    return copyableData;
 }
 
 #pragma mark - NSObject

--- a/JSQMessagesViewController/Model/JSQMessageMediaData.h
+++ b/JSQMessagesViewController/Model/JSQMessageMediaData.h
@@ -36,6 +36,18 @@
  */
 @protocol JSQMessageMediaData <NSObject>
 
+/**
+ *  A constant that is the UTType key for the dictionary of UIPasteboard copyable data in a 
+ *  `JSQMessageMediaData` compliant protocol object with the optional copyableMediaItem method implemented.
+ */
+FOUNDATION_EXPORT NSString * const JSQPasteboardUTTypeKey;
+
+/**
+ *  A constant that is the data key for the dictionary of UIPasteboard copyable data in a 
+ * `JSQMessageMediaData` compliant protocol object with the optional copyableMediaItem method implemented.
+ */
+FOUNDATION_EXPORT NSString * const JSQPasteboardDataKey;
+
 @required
 
 /**
@@ -77,5 +89,18 @@
  *  This value is used to cache layout information in the collection view.
  */
 - (NSUInteger)mediaHash;
+
+@optional
+
+/**
+ *  @return An `NSDictionary` with two keys representing the UTType and data 
+ *  (NSString, NSArray, NSURL, NSData, etc...) of this media object.
+ *
+ *  @discussion Implementing this optional method allows for the media object to be copyable 
+ *  onto the UIPasteboard for use in other applications.
+ *
+ *  @warning You should not return `nil` from this method, instead, do not override it.
+ */
+- (NSDictionary *)copyableMediaItem;
 
 @end

--- a/JSQMessagesViewController/Model/JSQMessageMediaData.m
+++ b/JSQMessagesViewController/Model/JSQMessageMediaData.m
@@ -1,0 +1,22 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import "JSQMessageMediaData.h"
+
+NSString * const JSQPasteboardUTTypeKey = @"JSQPasteboardUTTypeKey";
+NSString * const JSQPasteboardDataKey = @"JSQPasteboardDataKey";

--- a/JSQMessagesViewController/Model/JSQPhotoMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQPhotoMediaItem.m
@@ -21,6 +21,7 @@
 #import "JSQMessagesMediaPlaceholderView.h"
 #import "JSQMessagesMediaViewBubbleImageMasker.h"
 
+#import <MobileCoreServices/UTCoreTypes.h>
 
 @interface JSQPhotoMediaItem ()
 
@@ -87,6 +88,13 @@
 - (NSUInteger)mediaHash
 {
     return self.hash;
+}
+
+- (NSDictionary *)copyableMediaItem {
+    NSData *imageData = UIImageJPEGRepresentation(self.image, 1);
+    NSDictionary *copyableData = @{ JSQPasteboardUTTypeKey: (NSString *)kUTTypeJPEG, JSQPasteboardDataKey: imageData };
+    
+    return copyableData;
 }
 
 #pragma mark - NSObject


### PR DESCRIPTION
Attempt to implement #693 

- Created new optional protocol method `copyableMediaItem` on `JSQMessageMediaData` indicating ability to represent media item in form that can be copied to UIPasteboard. Returns `NSDictionary` representation of item with new constants to access items.
- Implement ability to copy `JSQLocationMediaItem` as NSURL linking to Google Maps (lat/lng)
- Implement ability to copy `JSQPhotoMediaItem` as NSData copyable to other apps (JPEG representation)
- Update `JSQMessageViewController` to allow copying of items that implement optional `copyableMediaItem` method on `JSQMessageMediaData`.
- Add `MobileCoreServices` framework needed for UTTypes constants.
- Add tests for new `copyableMediaItem` functionality for both `JSQLocationMediaItem` and `JSQPhotoMediaItem`

I also tried to add the same copy functionality to `JSQVideoMediaItem` but am scratching my head as to what the correct UTType is. The file itself is perfectly intact when emailed and file extension is re-added so it's something else... *smh*

Hopefully this isn't too big for one PR. After getting the necessary changes to `JSQMessagesViewController` to properly support copying `JSQLocationMediaItem`, it took less than 30 min to implement and test `JSQPhotoMediaItem` too. Figured might as well do them both at once.