### PR TITLE
Don't return spring behavior for attributes with empty size.

### DIFF
--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
@@ -541,17 +541,15 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
 
 - (UIAttachmentBehavior *)jsq_springBehaviorWithLayoutAttributesItem:(UICollectionViewLayoutAttributes *)item
 {
-    UIAttachmentBehavior *springBehavior = nil;
-    
-    // Don't return spring behavior for attributes with empty size.
-    // Otherwise will trigger failures when calling -addBehavior: in -prepareForCollectionViewUpdates:
-    if (!CGSizeEqualToSize(item.frame.size, CGSizeZero)) {
-        springBehavior = [[UIAttachmentBehavior alloc] initWithItem:item attachedToAnchor:item.center];
-        springBehavior.length = 1.0f;
-        springBehavior.damping = 1.0f;
-        springBehavior.frequency = 1.0f;
+    if (CGSizeEqualToSize(item.frame.size, CGSizeZero)) {
+        // adding a spring behavior with zero size will fail in in -prepareForCollectionViewUpdates:
+        return nil;
     }
     
+    UIAttachmentBehavior *springBehavior = [[UIAttachmentBehavior alloc] initWithItem:item attachedToAnchor:item.center];
+    springBehavior.length = 1.0f;
+    springBehavior.damping = 1.0f;
+    springBehavior.frequency = 1.0f;
     return springBehavior;
 }
 

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
@@ -541,10 +541,17 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
 
 - (UIAttachmentBehavior *)jsq_springBehaviorWithLayoutAttributesItem:(UICollectionViewLayoutAttributes *)item
 {
-    UIAttachmentBehavior *springBehavior = [[UIAttachmentBehavior alloc] initWithItem:item attachedToAnchor:item.center];
-    springBehavior.length = 1.0f;
-    springBehavior.damping = 1.0f;
-    springBehavior.frequency = 1.0f;
+    UIAttachmentBehavior *springBehavior = nil;
+    
+    // Don't return spring behavior for attributes with empty size.
+    // Otherwise will trigger failures when calling -addBehavior: in -prepareForCollectionViewUpdates:
+    if (!CGSizeEqualToSize(item.frame.size, CGSizeZero)) {
+        springBehavior = [[UIAttachmentBehavior alloc] initWithItem:item attachedToAnchor:item.center];
+        springBehavior.length = 1.0f;
+        springBehavior.damping = 1.0f;
+        springBehavior.frequency = 1.0f;
+    }
+    
     return springBehavior;
 }
 


### PR DESCRIPTION
Issue reference: #887.

The demo project currently displays a new outgoing message using JSQMessagesViewController -finishSendingMessageAnimated:, which calls UICollectionView -reloadData. This works fine. However when new items are instead added using UICollectionView -insertItemsAtIndexPaths:, a failure occurs in the flow layout when trying to add the spring behavior to the UIDynamicAnimator in -prepareForCollectionViewUpdates:. This change protects against that failure, which is caused by an invalid zero size in the layout attributes. Adding a nil behavior instead behaves correctly.