### PR TITLE
Fix segfault crashes

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -162,6 +162,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     _collectionView.dataSource = nil;
     _collectionView.delegate = nil;
     _collectionView = nil;
+    _inputToolbar.contentView.textView.delegate = nil;
+    _inputToolbar.delegate = nil;
     _inputToolbar = nil;
 
     _toolbarHeightConstraint = nil;


### PR DESCRIPTION
I'm not sure if this can be reproduced with demo project, but
when using this library somehow certain views outlive view controller
and cause crashes when trying to invoke delegate methods.