### PR TITLE
Revert @import for #import.

### DIFF
--- a/JSQMessagesViewController/Categories/NSBundle+JSQMessages.h
+++ b/JSQMessagesViewController/Categories/NSBundle+JSQMessages.h
@@ -16,7 +16,7 @@
 //  Released under an MIT license: http://opensource.org/licenses/MIT
 //
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @interface NSBundle (JSQMessages)
 


### PR DESCRIPTION
The problem is described in #541. I wasn't able to compile JSQMessagesViewController in our project. Reverting `@import` to `#import` should be fine.