### PR TITLE
Remove senderDisplayName and senderId properties in JSQMessagesViewController

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -39,13 +39,6 @@
     self.title = @"JSQMessages";
     
     /**
-     *  You MUST set your senderId and display name
-     */
-    self.senderId = kJSQDemoAvatarIdSquires;
-    self.senderDisplayName = kJSQDemoAvatarDisplayNameSquires;
-    
-    
-    /**
      *  Load up our fake data for the demo
      */
     self.demoData = [[DemoModelData alloc] init];
@@ -348,6 +341,16 @@
 
 
 #pragma mark - JSQMessages CollectionView DataSource
+
+- (NSString *)senderDisplayName
+{
+    return kJSQDemoAvatarDisplayNameSquires;
+}
+
+- (NSString *)senderId
+{
+    return kJSQDemoAvatarIdSquires;
+}
 
 - (id<JSQMessageData>)collectionView:(JSQMessagesCollectionView *)collectionView messageDataForItemAtIndexPath:(NSIndexPath *)indexPath
 {

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -45,22 +45,6 @@
 @property (weak, nonatomic, readonly) JSQMessagesInputToolbar *inputToolbar;
 
 /**
- *  The display name of the current user who is sending messages.
- *
- *  @discussion This value does not have to be unique. This value must not be `nil`.
- */
-@property (copy, nonatomic) NSString *senderDisplayName;
-
-/**
- *  The string identifier that uniquely identifies the current user sending messages.
- *  
- *  @discussion This property is used to determine if a message is incoming or outgoing.
- *  All message data objects returned by `collectionView:messageDataForItemAtIndexPath:` are
- *  checked against this identifier. This value must not be `nil`.
- */
-@property (copy, nonatomic) NSString *senderId;
-
-/**
  *  Specifies whether or not the view controller should automatically scroll to the most recent message 
  *  when the view appears and when sending, receiving, and composing a new message.
  *

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -170,8 +170,6 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     _toolbarHeightConstraint = nil;
     _toolbarBottomLayoutGuide = nil;
 
-    _senderId = nil;
-    _senderDisplayName = nil;
     _outgoingCellIdentifier = nil;
     _incomingCellIdentifier = nil;
 
@@ -224,9 +222,6 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (void)viewWillAppear:(BOOL)animated
 {
-    NSParameterAssert(self.senderId != nil);
-    NSParameterAssert(self.senderDisplayName != nil);
-
     [super viewWillAppear:animated];
     [self.view layoutIfNeeded];
     [self.collectionView.collectionViewLayout invalidateLayout];
@@ -402,6 +397,18 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 #pragma mark - JSQMessages collection view data source
 
+- (NSString *)senderDisplayName
+{
+    NSAssert(NO, @"ERROR: required method not implemented: %s", __PRETTY_FUNCTION__);
+    return nil;    
+}
+
+- (NSString *)senderId
+{
+    NSAssert(NO, @"ERROR: required method not implemented: %s", __PRETTY_FUNCTION__);
+    return nil;
+}
+
 - (id<JSQMessageData>)collectionView:(JSQMessagesCollectionView *)collectionView messageDataForItemAtIndexPath:(NSIndexPath *)indexPath
 {
     NSAssert(NO, @"ERROR: required method not implemented: %s", __PRETTY_FUNCTION__);
@@ -455,7 +462,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     NSString *messageSenderId = [messageItem senderId];
     NSParameterAssert(messageSenderId != nil);
 
-    BOOL isOutgoingMessage = [messageSenderId isEqualToString:self.senderId];
+    BOOL isOutgoingMessage = [messageSenderId isEqualToString:[collectionView.dataSource senderId]];
     BOOL isMediaMessage = [messageItem isMediaMessage];
 
     NSString *cellIdentifier = nil;
@@ -659,8 +666,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     else {
         [self didPressSendButton:sender
                  withMessageText:[self jsq_currentlyComposedMessageText]
-                        senderId:self.senderId
-               senderDisplayName:self.senderDisplayName
+                        senderId:[self.collectionView.dataSource senderId]
+               senderDisplayName:[self.collectionView.dataSource senderDisplayName]
                             date:[NSDate date]];
     }
 }
@@ -670,8 +677,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     if (toolbar.sendButtonOnRight) {
         [self didPressSendButton:sender
                  withMessageText:[self jsq_currentlyComposedMessageText]
-                        senderId:self.senderId
-               senderDisplayName:self.senderDisplayName
+                        senderId:[self.collectionView.dataSource senderId]
+               senderDisplayName:[self.collectionView.dataSource senderDisplayName]
                             date:[NSDate date]];
     }
     else {


### PR DESCRIPTION
So those properties serve the same purpose as required methods in data source. Why not get rid of them completely and fix #774, #918.