### PR TITLE
Exposing messageBubbleExtraVerticalSpace on flow layout

### DIFF
--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.h
@@ -119,6 +119,19 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault;
 @property (assign, nonatomic) CGFloat messageBubbleLeftRightMargin;
 
 /**
+ *  Add extra points of vertical space to calculation of messageBubbleSize,
+ *  because `boundingRectWithSize:` is slightly off. not sure why. magix. (shrug) if you know, submit a PR
+ *  This value is exposed because the right choice could depend on your choice of messageBubble font. If you
+ *  find that your chat text is for example magically cut off or has too much space, adjust this value
+ *  until you find the right visual fit
+ *
+ *  @discussion Default value is 2.0f.
+ *
+ *  @warning Adjusting this value is an advanced endeavour and not recommended.
+ */
+@property (assign, nonatomic) CGFloat messageBubbleExtraVerticalSpace;
+
+/**
  *  The inset of the frame of the text view within the `messageBubbleContainerView` of each `JSQMessagesCollectionViewCell`.
  *  The inset values should be positive and are applied in the following ways:
  *  

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
@@ -95,7 +95,7 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
     else {
         _messageBubbleLeftRightMargin = 50.0f;
     }
-    
+    _messageBubbleExtraVerticalSpace = 2.0f;
     _messageBubbleTextViewFrameInsets = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 6.0f);
     _messageBubbleTextViewTextContainerInsets = UIEdgeInsetsMake(7.0f, 14.0f, 7.0f, 14.0f);
     
@@ -466,12 +466,12 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
         CGFloat verticalContainerInsets = self.messageBubbleTextViewTextContainerInsets.top + self.messageBubbleTextViewTextContainerInsets.bottom;
         CGFloat verticalFrameInsets = self.messageBubbleTextViewFrameInsets.top + self.messageBubbleTextViewFrameInsets.bottom;
         
-        //  add extra 2 points of space, because `boundingRectWithSize:` is slightly off
+        //  add extra space, because `boundingRectWithSize:` is slightly off
         //  not sure why. magix. (shrug) if you know, submit a PR
-        CGFloat verticalInsets = verticalContainerInsets + verticalFrameInsets + 2.0f;
+        CGFloat verticalInsets = verticalContainerInsets + verticalFrameInsets + self.messageBubbleExtraVerticalSpace;
         
-        //  same as above, an extra 2 points of magix
-        CGFloat finalWidth = MAX(stringSize.width + horizontalInsetsTotal, self.bubbleImageAssetWidth) + 2.0f;
+        //  same as above, an extra magix extra space
+        CGFloat finalWidth = MAX(stringSize.width + horizontalInsetsTotal, self.bubbleImageAssetWidth) + self.messageBubbleExtraVerticalSpace;
         
         finalSize = CGSizeMake(finalWidth, stringSize.height + verticalInsets);
     }

--- a/JSQMessagesViewController/Model/JSQMessagesCollectionViewDataSource.h
+++ b/JSQMessagesViewController/Model/JSQMessagesCollectionViewDataSource.h
@@ -41,7 +41,7 @@
  *  
  *  @warning You must not return `nil` from this method. This value does not need to be unique.
  */
-- (NSString *)senderDisplayName;
+@property (nonatomic, copy, readonly) NSString *senderDisplayName;
 
 /**
  *  Asks the data source for the current sender's unique identifier, that is, the current user who is sending messages.
@@ -50,7 +50,7 @@
  *
  *  @warning You must not return `nil` from this method. This value must be unique.
  */
-- (NSString *)senderId;
+@property (nonatomic, copy, readonly) NSString *senderId;
 
 /**
  *  Asks the data source for the message data that corresponds to the specified item at indexPath in the collectionView.


### PR DESCRIPTION
 to work around `boundingRectWithSize` being slightly off for different fonts issue.

This value is exposed because the right choice could depend on your choice of messageBubble font. If you find that your chat text is for example magically cut off or has too much space, adjust this value until you find the right visual fit. While it's not the _right_ solution, the default magix number of `2.0f` is only appropriate for the default font, each font seems to be calculated slightly off in its own way. 
