### PR TITLE
Remove unneeded CGContext Save and Restore calls.

### DIFF
--- a/JSQMessagesViewController/Factories/JSQMessagesAvatarImageFactory.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesAvatarImageFactory.m
@@ -130,7 +130,6 @@
     UIGraphicsBeginImageContextWithOptions(frame.size, NO, [UIScreen mainScreen].scale);
     {
         CGContextRef context = UIGraphicsGetCurrentContext();
-        CGContextSaveGState(context);
 
         CGContextSetFillColorWithColor(context, backgroundColor.CGColor);
         CGContextFillRect(context, frame);
@@ -138,7 +137,6 @@
 
         image = UIGraphicsGetImageFromCurrentImageContext();
 
-        CGContextRestoreGState(context);
     }
     UIGraphicsEndImageContext();
 
@@ -156,7 +154,6 @@
     UIGraphicsBeginImageContextWithOptions(frame.size, NO, [UIScreen mainScreen].scale);
     {
         CGContextRef context = UIGraphicsGetCurrentContext();
-        CGContextSaveGState(context);
 
         UIBezierPath *imgPath = [UIBezierPath bezierPathWithOvalInRect:frame];
         [imgPath addClip];
@@ -168,8 +165,7 @@
         }
 
         newImage = UIGraphicsGetImageFromCurrentImageContext();
-
-        CGContextRestoreGState(context);
+        
     }
     UIGraphicsEndImageContext();
     


### PR DESCRIPTION
In the private class methods of JSQMessagesAvatarImageFactory
(jsq_imageWitInitials, jsq_circularImage) there were calls to save and restore
the state of the graphic context.

The calls are not needed because UIGraphicsBeginImageContext creates a new
context in a default state.