### PR TITLE
Renamed custom action method

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -533,14 +533,14 @@
 - (void)collectionView:(UICollectionView *)collectionView performAction:(SEL)action forItemAtIndexPath:(NSIndexPath *)indexPath withSender:(id)sender
 {
     if (action == @selector(customAction:)) {
-        [self customAction:sender];
+        [self performCustomAction:sender];
         return;
     }
 
     [super collectionView:collectionView performAction:action forItemAtIndexPath:indexPath withSender:sender];
 }
 
-- (void)customAction:(id)sender
+- (void)performCustomAction:(id)sender
 {
     NSLog(@"Custom action received! Sender: %@", sender);
 


### PR DESCRIPTION
This prevents the custom action being present in the input text view menu. Another case of "Singletons shouldn't be the first choice" - this application wide shared menu controller is just horrible :-(

@nikkoss the issue you mentioned in #811 arose because the `customAction:` selector is registered at the `UIMenuController` and `DemoMessageViewController` did implement it. When the context menu of the text input is shown, the menu controller checks if the underlying object(s? - I guess the views, but for sure the view controller) responds to the selector. In case of `customAction:` it did, so the action was added.

I see two ways around this: 1. proxy to a different selector (see this PR) with the downside of `Undeclared selector` warnings. 2. Let another object than the view controller be the collection view delegate. This would require some major code restructuring.