### PR TITLE
Adding missing 's' on the portuguese version of JSQMessages.strings

### DIFF
--- a/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/pt.lproj/JSQMessages.strings
+++ b/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/pt.lproj/JSQMessages.strings
@@ -22,7 +22,7 @@
 //  https://github.com/jessesquires/JSQMessagesViewController/issues/237
 //  ********************************
 
-"load_earlier_messages" = "Carregar mensagens anteriore";
+"load_earlier_messages" = "Carregar mensagens anteriores";
 
 "send" = "Enviar";
 


### PR DESCRIPTION
I realized that was missing an "s" on the portuguese version of JSQMessages.strings, so I added it.