### PR TITLE
Fixed crash #1026

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -250,7 +250,7 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 - (void)forwardInvocation:(NSInvocation *)anInvocation
 {
     if ([jsqMessagesCollectionViewCellActions containsObject:NSStringFromSelector(anInvocation.selector)]) {
-        id sender;
+        __unsafe_unretained id sender;
         [anInvocation getArgument:&sender atIndex:0];
         [self.delegate messagesCollectionViewCell:self didPerformAction:anInvocation.selector withSender:sender];
     }


### PR DESCRIPTION
by avoiding overreleasing the sender (the tapped message view cell) of a custom context menu action.