### PR TITLE
create override points for customizing nibs

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
@@ -52,23 +52,23 @@
     self.alwaysBounceVertical = YES;
     self.bounces = YES;
     
-    [self registerNib:[JSQMessagesCollectionViewCellIncoming nib]
+    [self registerNib:[self nibForIncomingCell]
           forCellWithReuseIdentifier:[JSQMessagesCollectionViewCellIncoming cellReuseIdentifier]];
     
-    [self registerNib:[JSQMessagesCollectionViewCellOutgoing nib]
+    [self registerNib:[self nibForOutgoingCell]
           forCellWithReuseIdentifier:[JSQMessagesCollectionViewCellOutgoing cellReuseIdentifier]];
     
-    [self registerNib:[JSQMessagesCollectionViewCellIncoming nib]
+    [self registerNib:[self nibForIncomingCell]
           forCellWithReuseIdentifier:[JSQMessagesCollectionViewCellIncoming mediaCellReuseIdentifier]];
     
-    [self registerNib:[JSQMessagesCollectionViewCellOutgoing nib]
+    [self registerNib:[self nibForOutgoingCell]
           forCellWithReuseIdentifier:[JSQMessagesCollectionViewCellOutgoing mediaCellReuseIdentifier]];
     
-    [self registerNib:[JSQMessagesTypingIndicatorFooterView nib]
+    [self registerNib:[self nibForTypingIndicatorFooterView]
           forSupplementaryViewOfKind:UICollectionElementKindSectionFooter
           withReuseIdentifier:[JSQMessagesTypingIndicatorFooterView footerReuseIdentifier]];
     
-    [self registerNib:[JSQMessagesLoadEarlierHeaderView nib]
+    [self registerNib:[self nibForLoadEarlierHeaderView]
           forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
           withReuseIdentifier:[JSQMessagesLoadEarlierHeaderView headerReuseIdentifier]];
 
@@ -180,6 +180,24 @@
                     performAction:action
                forItemAtIndexPath:indexPath
                        withSender:sender];
+}
+
+#pragma mark - Subclassing
+
+- (UINib *)nibForIncomingCell {
+	return [JSQMessagesCollectionViewCellIncoming nib];
+}
+
+- (UINib *)nibForOutgoingCell {
+	return [JSQMessagesCollectionViewCellOutgoing nib];
+}
+
+- (UINib *)nibForTypingIndicatorFooterView {
+	return [JSQMessagesTypingIndicatorFooterView nib];
+}
+
+- (UINib *)nibForLoadEarlierHeaderView {
+	return [JSQMessagesLoadEarlierHeaderView nib];
 }
 
 @end


### PR DESCRIPTION
@jessesquires 

This small changeset will allow a developer to:
1. in their xib, set a custom subclass of JSQMessagesCollectionView which can change the header/footer views, provided those new cells are subclasses of the JSQ classes they're customizing.

Hopefully you agree this is a low risk change which has no impact to existing projects.
Let me know if you have issues here. There are other ways to resolve this, but this felt the cleanest.

Ray