### PR TITLE
Smooth scrolling! 

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -527,8 +527,6 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
         cell.messageBubbleTopLabel.textInsets = UIEdgeInsetsMake(0.0f, bubbleTopLabelInset, 0.0f, 0.0f);
     }
 
-    cell.textView.dataDetectorTypes = UIDataDetectorTypeAll;
-
     cell.backgroundColor = [UIColor clearColor];
     
     return cell;

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -530,9 +530,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     cell.textView.dataDetectorTypes = UIDataDetectorTypeAll;
 
     cell.backgroundColor = [UIColor clearColor];
-    cell.layer.rasterizationScale = [UIScreen mainScreen].scale;
-    cell.layer.shouldRasterize = YES;
-
+    
     return cell;
 }
 

--- a/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.m
@@ -20,7 +20,9 @@
 
 @interface JSQMessagesTimestampFormatter ()
 
+// Separate formatters for the Date & Time parts for performance reasons
 @property (strong, nonatomic, readwrite) NSDateFormatter *dateFormatter;
+@property (strong, nonatomic, readwrite) NSDateFormatter *timeFormatter;
 
 @end
 
@@ -50,6 +52,9 @@
         [_dateFormatter setLocale:[NSLocale currentLocale]];
         [_dateFormatter setDoesRelativeDateFormatting:YES];
         
+        _timeFormatter = [[NSDateFormatter alloc] init];
+        [_timeFormatter setLocale:[NSLocale currentLocale]];
+        
         UIColor *color = [UIColor lightGrayColor];
         
         NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
@@ -69,6 +74,7 @@
 - (void)dealloc
 {
     _dateFormatter = nil;
+    _timeFormatter = nil;
     _dateTextAttributes = nil;
     _timeTextAttributes = nil;
 }
@@ -81,9 +87,10 @@
         return nil;
     }
     
-    [self.dateFormatter setDateStyle:NSDateFormatterMediumStyle];
-    [self.dateFormatter setTimeStyle:NSDateFormatterShortStyle];
-    return [self.dateFormatter stringFromDate:date];
+    NSString *relativeDate = [self relativeDateForDate:date];
+    NSString *time = [self timeForDate:date];
+    
+    return [NSString stringWithFormat:@"%@ %@", relativeDate, time];
 }
 
 - (NSAttributedString *)attributedTimestampForDate:(NSDate *)date
@@ -112,9 +119,9 @@
         return nil;
     }
     
-    [self.dateFormatter setDateStyle:NSDateFormatterNoStyle];
-    [self.dateFormatter setTimeStyle:NSDateFormatterShortStyle];
-    return [self.dateFormatter stringFromDate:date];
+    [self.timeFormatter setDateStyle:NSDateFormatterNoStyle];
+    [self.timeFormatter setTimeStyle:NSDateFormatterShortStyle];
+    return [self.timeFormatter stringFromDate:date];
 }
 
 - (NSString *)relativeDateForDate:(NSDate *)date

--- a/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.m
@@ -90,7 +90,7 @@
     NSString *relativeDate = [self relativeDateForDate:date];
     NSString *time = [self timeForDate:date];
     
-    return [NSString stringWithFormat:@"%@ %@", relativeDate, time];
+    return [NSString stringWithFormat:@"%@, %@", relativeDate, time];
 }
 
 - (NSAttributedString *)attributedTimestampForDate:(NSDate *)date

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
@@ -18,7 +18,9 @@
 
 #import "JSQMessagesCellTextView.h"
 
-@implementation JSQMessagesCellTextView
+@implementation JSQMessagesCellTextView {
+    BOOL _hasText;
+}
 
 - (void)awakeFromNib
 {
@@ -44,6 +46,38 @@
     self.textContainer.lineFragmentPadding = 0;
     self.linkTextAttributes = @{ NSForegroundColorAttributeName : [UIColor whiteColor],
                                  NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle | NSUnderlinePatternSolid) };
+}
+
+// In prepareForReuse we would set the text to nil,
+// and then we would set the text to the correct value.
+// This dance takes time, especially with data detectors in place.
+// We make sure that the outside can see the correct values and we do layout.
+- (void)setText:(NSString *)text
+{
+    if (text) {
+        [super setText:text];
+    }
+    _hasText = !!text.length;
+    [self setNeedsLayout];
+}
+
+- (NSString *)text
+{
+    return (_hasText) ?  [super text] :  nil;
+}
+
+- (void)setAttributedText:(NSAttributedString *)attributedText
+{
+    if (attributedText) {
+        [super setAttributedText:attributedText];
+    }
+    _hasText = !!attributedText.length;
+    [self setNeedsLayout];
+}
+
+- (NSAttributedString *)attributedText
+{
+    return (_hasText) ? [super attributedText] : nil;
 }
 
 - (void)setSelectedRange:(NSRange)selectedRange

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
@@ -30,10 +30,10 @@
     self.editable = NO;
     self.selectable = YES;
     self.userInteractionEnabled = YES;
-    self.dataDetectorTypes = UIDataDetectorTypeNone;
+    self.dataDetectorTypes = UIDataDetectorTypeAll;
     self.showsHorizontalScrollIndicator = NO;
     self.showsVerticalScrollIndicator = NO;
-    
+
     // This degraded scrolling performance, but it's still unclear as to why.
     // With accurate layout scrolling will not be possible anyway.
     // self.scrollEnabled = NO;

--- a/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCellTextView.m
@@ -31,7 +31,11 @@
     self.dataDetectorTypes = UIDataDetectorTypeNone;
     self.showsHorizontalScrollIndicator = NO;
     self.showsVerticalScrollIndicator = NO;
-    self.scrollEnabled = NO;
+    
+    // This degraded scrolling performance, but it's still unclear as to why.
+    // With accurate layout scrolling will not be possible anyway.
+    // self.scrollEnabled = NO;
+    
     self.backgroundColor = [UIColor clearColor];
     self.contentInset = UIEdgeInsetsZero;
     self.scrollIndicatorInsets = UIEdgeInsetsZero;

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -160,7 +160,6 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     self.messageBubbleTopLabel.text = nil;
     self.cellBottomLabel.text = nil;
 
-    self.textView.dataDetectorTypes = UIDataDetectorTypeNone;
     self.textView.text = nil;
     self.textView.attributedText = nil;
 


### PR DESCRIPTION
I made scrolling perfect on my iPhone 5s **without removing auto-layout**.

I commented on every commit.

Basically the changes in order of their importance:
- `textView.scrollEnabled=NO` causes scrolling problems for some reason, but it can be safely disabled because the layout takes care of that
-  `NSDateFormatter` optimized by having separate Date & Time formatters and not changing the style of a single formatter all the time.
- make sure we don’t cause unnecessary work with `setText=nil` upon cell reuse 
- remove forced rasterization to unburden the CPU
- move default dataDetector setting to `textView.awakeFromNib` instead of `cellForRowAtIndexPath` so library users can have better control

The biggest bottleneck left seems to be `dataDetectors` as they heavily block the main thread.

When _testing_ this PR I advise you to **disable** them to see the smoothness achieved by these commits (without being affected by dataDetectors).

Maybe later I’ll come up with something to make that part faster as well.
