### PR TITLE
Attributed text messages

### DIFF
--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		36CF33BD29CF36EB06D0CCFD /* libPods-JSQMessagesTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 782026E9E518622532ED474D /* libPods-JSQMessagesTests.a */; };
+		72890B021B41E7A90065EC7E /* JSQAttributedMessage.m in Sources */ = {isa = PBXBuildFile; fileRef = 72890B011B41E7A90065EC7E /* JSQAttributedMessage.m */; };
 		77CC17A895E6E12BC9CB549A /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 97E6750B77E8A7042BA0754B /* libPods.a */; };
 		88078A9D19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 88078A9C19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m */; };
 		88324C3419F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88324C3319F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m */; };
@@ -122,6 +123,9 @@
 		0844AD596023C7658D39E241 /* Pods-JSQMessagesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.release.xcconfig"; sourceTree = "<group>"; };
 		223FBACE0F24ADEF8B7F3F24 /* Pods-JSQMessagesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.debug.xcconfig"; sourceTree = "<group>"; };
 		27B7FD1B722B36B26CB3460B /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		72890B001B41E7A90065EC7E /* JSQAttributedMessage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQAttributedMessage.h; sourceTree = "<group>"; };
+		72890B011B41E7A90065EC7E /* JSQAttributedMessage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQAttributedMessage.m; sourceTree = "<group>"; };
+		72890B031B41E7F20065EC7E /* JSQMessageAttributedData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSQMessageAttributedData.h; sourceTree = "<group>"; };
 		782026E9E518622532ED474D /* libPods-JSQMessagesTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JSQMessagesTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		88078A9B19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesMediaPlaceholderView.h; sourceTree = "<group>"; };
 		88078A9C19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaPlaceholderView.m; sourceTree = "<group>"; };
@@ -486,6 +490,9 @@
 		88A25F7619D8E01A00924534 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				72890B031B41E7F20065EC7E /* JSQMessageAttributedData.h */,
+				72890B001B41E7A90065EC7E /* JSQAttributedMessage.h */,
+				72890B011B41E7A90065EC7E /* JSQAttributedMessage.m */,
 				88445B3E19E1B4470014F889 /* JSQLocationMediaItem.h */,
 				88445B3F19E1B4470014F889 /* JSQLocationMediaItem.m */,
 				88A901B419F618B100F99777 /* JSQMediaItem.h */,
@@ -809,6 +816,7 @@
 				88A25FCE19D8E01A00924534 /* JSQMessagesCollectionViewCellOutgoing.m in Sources */,
 				88A25FD119D8E01A00924534 /* JSQMessagesInputToolbar.m in Sources */,
 				88A25FCB19D8E01A00924534 /* JSQMessagesCollectionViewCell.m in Sources */,
+				72890B021B41E7A90065EC7E /* JSQAttributedMessage.m in Sources */,
 				88A25FBB19D8E01A00924534 /* JSQMessagesViewController.m in Sources */,
 				8885734D19DE55D000E89D20 /* NSUserDefaults+DemoSettings.m in Sources */,
 				883C11781A09FB100092A16D /* JSQMessagesCellTextView.m in Sources */,

--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -499,7 +499,7 @@
     
     JSQMessage *msg = [self.demoData.messages objectAtIndex:indexPath.item];
     
-    if (!msg.isMediaMessage) {
+    if (!msg.isMediaMessage && ![msg isKindOfClass:[JSQAttributedMessage class]]) {
         
         if ([msg.senderId isEqualToString:self.senderId]) {
             cell.textView.textColor = [UIColor blackColor];

--- a/JSQMessagesDemo/DemoModelData.m
+++ b/JSQMessagesDemo/DemoModelData.m
@@ -130,6 +130,28 @@
                                                      text:@"Now with media messages!"],
                      nil];
     
+    
+    /**
+     Testing: Attributed Strings
+     */
+    NSMutableAttributedString* attributedString = [NSMutableAttributedString new];
+    
+    [attributedString appendAttributedString:[[NSAttributedString alloc]
+                                              initWithString:@"Good News!"
+                                              attributes:@{NSFontAttributeName:[UIFont boldSystemFontOfSize:18],
+                                                           NSForegroundColorAttributeName:[UIColor whiteColor]}]];
+    
+    [attributedString appendAttributedString:[[NSAttributedString alloc]
+                                              initWithString:@"\nNow with attributed strings"
+                                              attributes:@{NSFontAttributeName:[UIFont italicSystemFontOfSize:14],
+                                                           NSForegroundColorAttributeName:[UIColor redColor]}]];
+    
+    [self.messages addObject:[[JSQAttributedMessage alloc]initWithSenderId:kJSQDemoAvatarIdCook
+                                                         senderDisplayName:kJSQDemoAvatarDisplayNameCook
+                                                                      date:[NSDate date]
+                                                            attributedText:attributedString]];
+
+    
     [self addPhotoMediaMessage];
     
     /**

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -21,6 +21,7 @@
 #import "JSQMessagesCollectionViewFlowLayoutInvalidationContext.h"
 
 #import "JSQMessageData.h"
+#import "JSQMessageAttributedData.h"
 #import "JSQMessageBubbleImageDataSource.h"
 #import "JSQMessageAvatarImageDataSource.h"
 
@@ -466,13 +467,20 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     cell.delegate = collectionView;
 
     if (!isMediaMessage) {
-        cell.textView.text = [messageItem text];
-
-        if ([UIDevice jsq_isCurrentDeviceBeforeiOS8]) {
-            //  workaround for iOS 7 textView data detectors bug
-            cell.textView.text = nil;
-            cell.textView.attributedText = [[NSAttributedString alloc] initWithString:[messageItem text]
-                                                                           attributes:@{ NSFontAttributeName : collectionView.collectionViewLayout.messageBubbleFont }];
+        
+        if ([messageItem conformsToProtocol:@protocol(JSQMessageAttributedData)]) {
+            id <JSQMessageAttributedData> attributedMessageItem =  (id <JSQMessageAttributedData>) messageItem;
+            cell.textView.attributedText = [attributedMessageItem attributedText];
+            
+        } else {
+            cell.textView.text = [messageItem text];
+            
+            if ([UIDevice jsq_isCurrentDeviceBeforeiOS8]) {
+                //  workaround for iOS 7 textView data detectors bug
+                cell.textView.text = nil;
+                cell.textView.attributedText = [[NSAttributedString alloc] initWithString:[messageItem text]
+                                                                               attributes:@{ NSFontAttributeName : collectionView.collectionViewLayout.messageBubbleFont }];
+            }
         }
 
         NSParameterAssert(cell.textView.text != nil);

--- a/JSQMessagesViewController/JSQMessages.h
+++ b/JSQMessagesViewController/JSQMessages.h
@@ -45,6 +45,7 @@
 #import "JSQPhotoMediaItem.h"
 #import "JSQLocationMediaItem.h"
 #import "JSQVideoMediaItem.h"
+#import "JSQAttributedMessage.h"
 
 #import "JSQMessagesBubbleImage.h"
 #import "JSQMessagesAvatarImage.h"

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
@@ -24,6 +24,7 @@
 #import "JSQMessagesCollectionViewFlowLayout.h"
 
 #import "JSQMessageData.h"
+#import "JSQMessageAttributedData.h"
 
 #import "JSQMessagesCollectionView.h"
 #import "JSQMessagesCollectionViewCell.h"
@@ -456,10 +457,21 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
         CGFloat horizontalInsetsTotal = horizontalContainerInsets + horizontalFrameInsets + spacingBetweenAvatarAndBubble;
         CGFloat maximumTextWidth = self.itemWidth - avatarSize.width - self.messageBubbleLeftRightMargin - horizontalInsetsTotal;
         
-        CGRect stringRect = [[messageItem text] boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
-                                                             options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)
-                                                          attributes:@{ NSFontAttributeName : self.messageBubbleFont }
-                                                             context:nil];
+        CGRect stringRect;
+        
+        if ([messageItem conformsToProtocol:@protocol(JSQMessageAttributedData)]) {
+            id <JSQMessageAttributedData> attributedMessageItem =  (id <JSQMessageAttributedData> )messageItem;
+            stringRect = [[attributedMessageItem  attributedText] boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
+                                                                               options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)
+                                                                               context:nil];
+            
+        } else {
+            
+            stringRect = [[messageItem text] boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
+                                                          options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)
+                                                       attributes:@{ NSFontAttributeName : self.messageBubbleFont }
+                                                          context:nil];
+        }
         
         CGSize stringSize = CGRectIntegral(stringRect).size;
         

--- a/JSQMessagesViewController/Model/JSQAttributedMessage.h
+++ b/JSQMessagesViewController/Model/JSQAttributedMessage.h
@@ -1,0 +1,60 @@
+//
+//  JSQAttributedMessage.h
+//  JSQMessages
+//
+//  Created by Flavio Negrão Torres on 29/06/15.
+//  Copyright (c) 2015 Hexed Bits. All rights reserved.
+//
+
+#import "JSQMessage.h"
+
+#import "JSQMessageAttributedData.h"
+
+@interface JSQAttributedMessage : JSQMessage <JSQMessageAttributedData>
+
+
+/**
+ *  Returns the body text of the message, or `nil` if the message is a media message.
+ *  That is, if `isMediaMessage` is equal to `YES` then this value will be `nil`.
+ */
+@property (copy, nonatomic, readonly) NSAttributedString *attributedText;
+
+
+#pragma mark - Initialization
+/**
+ *  Initializes and returns a message object having the given senderId, displayName, text,
+ *  and current system date.
+ *
+ *  @param senderId    The unique identifier for the user who sent the message. This value must not be `nil`.
+ *  @param displayName The display name for the user who sent the message. This value must not be `nil`.
+ *  @param text        The body text of the message. This value must not be `nil`.
+ *
+ *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `NO`.
+ *
+ *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
+ */
++ (instancetype)messageWithSenderId:(NSString *)senderId
+                        displayName:(NSString *)displayName
+                      attributedText:(NSAttributedString *) attributedText;
+
+
+/**
+ *  Initializes and returns a message object having the given senderId, senderDisplayName, date, and text.
+ *
+ *  @param senderId          The unique identifier for the user who sent the message. This value must not be `nil`.
+ *  @param senderDisplayName The display name for the user who sent the message. This value must not be `nil`.
+ *  @param date              The date that the message was sent. This value must not be `nil`.
+ *  @param text              The body text of the message. This value must not be `nil`.
+ *
+ *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `NO`.
+ *
+ *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
+ */
+- (instancetype)initWithSenderId:(NSString *)senderId
+               senderDisplayName:(NSString *)senderDisplayName
+                            date:(NSDate *)date
+                            attributedText:(NSAttributedString *) attributeText;
+
+
+
+@end

--- a/JSQMessagesViewController/Model/JSQAttributedMessage.h
+++ b/JSQMessagesViewController/Model/JSQAttributedMessage.h
@@ -1,9 +1,19 @@
 //
-//  JSQAttributedMessage.h
-//  JSQMessages
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
 //
-//  Created by Flavio Negrão Torres on 29/06/15.
-//  Copyright (c) 2015 Hexed Bits. All rights reserved.
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
 //
 
 #import "JSQMessage.h"
@@ -25,9 +35,9 @@
  *  Initializes and returns a message object having the given senderId, displayName, text,
  *  and current system date.
  *
- *  @param senderId    The unique identifier for the user who sent the message. This value must not be `nil`.
- *  @param displayName The display name for the user who sent the message. This value must not be `nil`.
- *  @param text        The body text of the message. This value must not be `nil`.
+ *  @param senderId       The unique identifier for the user who sent the message. This value must not be `nil`.
+ *  @param displayName    The display name for the user who sent the message. This value must not be `nil`.
+ *  @param attributedText The body attributed text of the message. This value must not be `nil`.
  *
  *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `NO`.
  *
@@ -41,10 +51,10 @@
 /**
  *  Initializes and returns a message object having the given senderId, senderDisplayName, date, and text.
  *
- *  @param senderId          The unique identifier for the user who sent the message. This value must not be `nil`.
- *  @param senderDisplayName The display name for the user who sent the message. This value must not be `nil`.
- *  @param date              The date that the message was sent. This value must not be `nil`.
- *  @param text              The body text of the message. This value must not be `nil`.
+ *  @param senderId             The unique identifier for the user who sent the message. This value must not be `nil`.
+ *  @param senderDisplayName    The display name for the user who sent the message. This value must not be `nil`.
+ *  @param date                 The date that the message was sent. This value must not be `nil`.
+ *  @param attributedText       The body atributed text of the message. This value must not be `nil`.
  *
  *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `NO`.
  *

--- a/JSQMessagesViewController/Model/JSQAttributedMessage.m
+++ b/JSQMessagesViewController/Model/JSQAttributedMessage.m
@@ -1,0 +1,45 @@
+//
+//  JSQAttributedMessage.m
+//  JSQMessages
+//
+//  Created by Flavio Negrão Torres on 29/06/15.
+//  Copyright (c) 2015 Hexed Bits. All rights reserved.
+//
+
+#import "JSQAttributedMessage.h"
+
+@implementation JSQAttributedMessage
+
+
+#pragma mark - Initialization
+
++ (instancetype)messageWithSenderId:(NSString *)senderId
+                        displayName:(NSString *)displayName
+                      attributedText:(NSAttributedString *) attributedText {
+    
+    return [[self alloc] initWithSenderId:senderId
+                              senderDisplayName:displayName
+                                           date:[NSDate date]
+                            attributedText:attributedText];
+    
+}
+
+
+- (instancetype)initWithSenderId:(NSString *)senderId
+               senderDisplayName:(NSString *)senderDisplayName
+                            date:(NSDate *)date
+                   attributedText:(NSAttributedString *) attributedText  {
+    
+    NSParameterAssert(senderId != nil);
+    NSParameterAssert(senderDisplayName != nil);
+    NSParameterAssert(date != nil);
+    
+    self = [super initWithSenderId:senderId senderDisplayName:senderDisplayName date:date text:attributedText.string];
+    if (self) {
+        _attributedText = [attributedText copy];
+    }
+    return self;
+}
+
+
+@end

--- a/JSQMessagesViewController/Model/JSQAttributedMessage.m
+++ b/JSQMessagesViewController/Model/JSQAttributedMessage.m
@@ -1,9 +1,19 @@
 //
-//  JSQAttributedMessage.m
-//  JSQMessages
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
 //
-//  Created by Flavio Negrão Torres on 29/06/15.
-//  Copyright (c) 2015 Hexed Bits. All rights reserved.
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
 //
 
 #import "JSQAttributedMessage.h"

--- a/JSQMessagesViewController/Model/JSQMessageAttributedData.h
+++ b/JSQMessagesViewController/Model/JSQMessageAttributedData.h
@@ -1,0 +1,20 @@
+//
+//  JSQMessageAttributedData.h
+//  JSQMessages
+//
+//  Created by Flavio Negrão Torres on 29/06/15.
+//  Copyright (c) 2015 Hexed Bits. All rights reserved.
+//
+
+#import "JSQMessageMediaData.h"
+
+@protocol JSQMessageAttributedData <JSQMessageData>
+
+/**
+ *  @return The body text of the message.
+ *
+ *  @warning You must not return `nil` from this method.
+ */
+- (NSAttributedString *)attributedText;
+
+@end

--- a/JSQMessagesViewController/Model/JSQMessageAttributedData.h
+++ b/JSQMessagesViewController/Model/JSQMessageAttributedData.h
@@ -1,9 +1,19 @@
 //
-//  JSQMessageAttributedData.h
-//  JSQMessages
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
 //
-//  Created by Flavio Negrão Torres on 29/06/15.
-//  Copyright (c) 2015 Hexed Bits. All rights reserved.
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
 //
 
 #import "JSQMessageMediaData.h"
@@ -11,7 +21,7 @@
 @protocol JSQMessageAttributedData <JSQMessageData>
 
 /**
- *  @return The body text of the message.
+ *  @return The body attributed text of the message.
  *
  *  @warning You must not return `nil` from this method.
  */


### PR DESCRIPTION
Hey, I've seen few requests(#1052, #520, ...) for adding attributed strings to the text bubbles.
I have implemented it, however don't know I was able to meet your coding style standards.
Hope it helps somehow, cheers 
![ios simulator screen shot 29 06 2015 6 16 47 pm](https://cloud.githubusercontent.com/assets/1597236/8418987/044382f8-1e8d-11e5-94e3-e96664310cf8.png)


Flavio