### PR TITLE
fix JSQMessage convenience inits return JSQMessage instead of instanc…

### DIFF
--- a/JSQMessagesViewController/Model/JSQMessage.m
+++ b/JSQMessagesViewController/Model/JSQMessage.m
@@ -38,7 +38,7 @@
                         displayName:(NSString *)displayName
                                text:(NSString *)text
 {
-    return [[JSQMessage alloc] initWithSenderId:senderId
+    return [[self alloc] initWithSenderId:senderId
                               senderDisplayName:displayName
                                            date:[NSDate date]
                                            text:text];
@@ -62,7 +62,7 @@
                         displayName:(NSString *)displayName
                               media:(id<JSQMessageMediaData>)media
 {
-    return [[JSQMessage alloc] initWithSenderId:senderId
+    return [[self alloc] initWithSenderId:senderId
                               senderDisplayName:displayName
                                            date:[NSDate date]
                                           media:media];


### PR DESCRIPTION
…etype.

This resulted in issue when subclassing JSQMessage and using those convenience initializers.