### PR TITLE
Update to allow any textField to move inputToolbar with the keyboard

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -791,10 +791,6 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (void)keyboardController:(JSQMessagesKeyboardController *)keyboardController keyboardDidChangeFrame:(CGRect)keyboardFrame
 {
-    if (![self.inputToolbar.contentView.textView isFirstResponder] && self.toolbarBottomLayoutGuide.constant == 0.0f) {
-        return;
-    }
-
     CGFloat heightFromBottom = CGRectGetMaxY(self.collectionView.frame) - CGRectGetMinY(keyboardFrame);
 
     heightFromBottom = MAX(0.0f, heightFromBottom);


### PR DESCRIPTION
If you are using a contact picker with JSQMessages, when the contact picker (or any other UITextField) gets first responder, the keyboard animates up an empty frame but leaves the inputToolbar at the bottom.  By removing the following code from JSQMessagesViewController, the inputToolbar moves with the keyboard with any first responder.

```Obj-C
if (![self.inputToolbar.contentView.textView isFirstResponder] && self.toolbarBottomLayoutGuide.constant == 0.0f) {
    return;
}
```
