### PR TITLE
Fixed pin image drawing in JSQLocationMediaItem.

### DIFF
--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -121,6 +121,12 @@
                   CGPoint coordinatePoint = [snapshot pointForCoordinate:location.coordinate];
                   UIImage *image = snapshot.image;
                   
+                  CGPoint pinCenterOffset = pin.centerOffset;
+                  coordinatePoint.x -= pin.bounds.size.width / 2.0;
+                  coordinatePoint.y -= pin.bounds.size.height / 2.0;
+                  coordinatePoint.x += pinCenterOffset.x;
+                  coordinatePoint.y += pinCenterOffset.y;
+                  
                   UIGraphicsBeginImageContextWithOptions(image.size, YES, image.scale);
                   {
                       [image drawAtPoint:CGPointZero];

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -121,11 +121,8 @@
                   CGPoint coordinatePoint = [snapshot pointForCoordinate:location.coordinate];
                   UIImage *image = snapshot.image;
                   
-                  CGPoint pinCenterOffset = pin.centerOffset;
-                  coordinatePoint.x -= pin.bounds.size.width / 2.0;
-                  coordinatePoint.y -= pin.bounds.size.height / 2.0;
-                  coordinatePoint.x += pinCenterOffset.x;
-                  coordinatePoint.y += pinCenterOffset.y;
+                  coordinatePoint.x += pin.centerOffset.x - (CGRectGetWidth(pin.bounds) / 2.0);
+                  coordinatePoint.y += pin.centerOffset.y - (CGRectGetHeight(pin.bounds) / 2.0);
                   
                   UIGraphicsBeginImageContextWithOptions(image.size, YES, image.scale);
                   {


### PR DESCRIPTION
:muscle::sunglasses::facepunch:

The current pin drawing doesn't take the pin image's `centerOffset` or size into account, and it draws the pin with its origin at `(0, 0)`

This PR adds math to account for the pin's size and center offset.

## Original Location
![screen shot 2015-08-14 at 10 24 18 am](https://cloud.githubusercontent.com/assets/853032/9275970/fca30a9a-426e-11e5-89f0-734b2c9d8598.png)

## Old behavior
![screen shot 2015-08-14 at 10 25 04 am](https://cloud.githubusercontent.com/assets/853032/9275975/0656642e-426f-11e5-995b-e4d585d81349.png)

## With this PR
![screen shot 2015-08-14 at 10 25 39 am](https://cloud.githubusercontent.com/assets/853032/9275977/0d9c699a-426f-11e5-99c9-83ab35368141.png)