### PR TITLE
create a property to control Rotation-Independent bubble width

### DIFF
--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
@@ -36,7 +36,7 @@
  *  @return An initialized `JSQMessagesBubblesSizeCalculator` object if successful, `nil` otherwise.
  */
 - (instancetype)initWithCache:(NSCache *)cache
-           minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
- usesFixedWidthMessageBubbles:(BOOL)fixedWidthMessageBubbles NS_DESIGNATED_INITIALIZER;
+		   minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
+		usesFixedWidthBubbles:(BOOL)fixedWidthMessageBubbles NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
@@ -29,14 +29,14 @@
 /**
  *  Initializes and returns a bubble size calculator with the given cache and minimumBubbleWidth.
  *
- *  @param cache                        A cache object used to store layout information.
- *  @param minimumBubbleWidth           The minimum width for any given message bubble.
- *  @param usesFixedWidthMessageBubbles Boolean indicating if you want same width bubbles in landscape & portrait
+ *  @param cache                 A cache object used to store layout information.
+ *  @param minimumBubbleWidth    The minimum width for any given message bubble.
+ *  @param usesFixedWidthBubbles Boolean indicating if you want same width bubbles in landscape & portrait
  *
  *  @return An initialized `JSQMessagesBubblesSizeCalculator` object if successful, `nil` otherwise.
  */
 - (instancetype)initWithCache:(NSCache *)cache
 		   minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
-		usesFixedWidthBubbles:(BOOL)fixedWidthMessageBubbles NS_DESIGNATED_INITIALIZER;
+		usesFixedWidthBubbles:(BOOL)fixedWidthBubbles NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
@@ -32,11 +32,13 @@
  *  @param cache                 A cache object used to store layout information.
  *  @param minimumBubbleWidth    The minimum width for any given message bubble.
  *  @param usesFixedWidthBubbles Boolean indicating if you want same width bubbles in landscape & portrait
+ *  @param additionalInset       Allows you to add additional pixels to chat bubble size calculations.
  *
  *  @return An initialized `JSQMessagesBubblesSizeCalculator` object if successful, `nil` otherwise.
  */
 - (instancetype)initWithCache:(NSCache *)cache
 		   minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
-		usesFixedWidthBubbles:(BOOL)usesFixedWidthBubbles NS_DESIGNATED_INITIALIZER;
+		usesFixedWidthBubbles:(BOOL)usesFixedWidthBubbles
+              additionalInset:(NSInteger)additionalInset NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
@@ -29,12 +29,14 @@
 /**
  *  Initializes and returns a bubble size calculator with the given cache and minimumBubbleWidth.
  *
- *  @param cache              A cache object used to store layout information.
- *  @param minimumBubbleWidth The minimum width for any given message bubble.
+ *  @param cache                        A cache object used to store layout information.
+ *  @param minimumBubbleWidth           The minimum width for any given message bubble.
+ *  @param usesFixedWidthMessageBubbles Boolean indicating if you want same width bubbles in landscape & portrait
  *
  *  @return An initialized `JSQMessagesBubblesSizeCalculator` object if successful, `nil` otherwise.
  */
 - (instancetype)initWithCache:(NSCache *)cache
-           minimumBubbleWidth:(NSUInteger)minimumBubbleWidth NS_DESIGNATED_INITIALIZER;
+           minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
+ usesFixedWidthMessageBubbles:(BOOL)fixedWidthMessageBubbles NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.h
@@ -37,6 +37,6 @@
  */
 - (instancetype)initWithCache:(NSCache *)cache
 		   minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
-		usesFixedWidthBubbles:(BOOL)fixedWidthBubbles NS_DESIGNATED_INITIALIZER;
+		usesFixedWidthBubbles:(BOOL)usesFixedWidthBubbles NS_DESIGNATED_INITIALIZER;
 
 @end

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
@@ -36,6 +36,11 @@
 
 @property (assign, nonatomic) NSInteger rotationIndependentLayoutWidth;
 
+//  Creating a getter for this magix value because we are using it in a couple of places.
+//  add extra 2 points of space, because `boundingRectWithSize:` is slightly off
+//  not sure why. magix. (shrug) if you know, submit a PR
+@property (nonatomic, readonly) NSInteger additionalInset;
+
 @end
 
 
@@ -46,6 +51,7 @@
 - (instancetype)initWithCache:(NSCache *)cache
            minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
         usesFixedWidthBubbles:(BOOL)usesFixedWidthBubbles
+              additionalInset:(NSInteger)additionalInset
 {
     NSParameterAssert(cache != nil);
     NSParameterAssert(minimumBubbleWidth > 0);
@@ -55,6 +61,7 @@
         _cache = cache;
         _minimumBubbleWidth = minimumBubbleWidth;
         _usesFixedWidthBubbles = usesFixedWidthBubbles;
+        _additionalInset = additionalInset;
     }
     return self;
 }
@@ -66,7 +73,8 @@
     cache.countLimit = 200;
     return [self initWithCache:cache
             minimumBubbleWidth:[UIImage jsq_bubbleCompactImage].size.width
-         usesFixedWidthBubbles:NO];
+         usesFixedWidthBubbles:NO
+            additionalInset:2];
 }
 
 #pragma mark - NSObject
@@ -121,10 +129,10 @@
 
         //  add extra 2 points of space, because `boundingRectWithSize:` is slightly off
         //  not sure why. magix. (shrug) if you know, submit a PR
-        CGFloat verticalInsets = verticalContainerInsets + verticalFrameInsets + [self magixInsetAddition];
+        CGFloat verticalInsets = verticalContainerInsets + verticalFrameInsets + [self additionalInset];
 
         //  same as above, an extra 2 points of magix
-        CGFloat finalWidth = MAX(stringSize.width + horizontalInsetsTotal, self.minimumBubbleWidth) + [self magixInsetAddition];
+        CGFloat finalWidth = MAX(stringSize.width + horizontalInsetsTotal, self.minimumBubbleWidth) + [self additionalInset];
 
         finalSize = CGSizeMake(finalWidth, stringSize.height + verticalInsets);
     }
@@ -146,20 +154,12 @@
     return layout.incomingAvatarViewSize;
 }
 
-- (NSInteger)magixInsetAddition {
-    //  Creating a getter for this magix value because we are using it in a couple of places.
-    //
-    //  add extra 2 points of space, because `boundingRectWithSize:` is slightly off
-    //  not sure why. magix. (shrug) if you know, submit a PR
-    return 2;
-}
-
 - (CGFloat)textBubbleWidthForLayout:(JSQMessagesCollectionViewFlowLayout *)layout
 {
     if (self.usesFixedWidthBubbles) {
         if (self.rotationIndependentLayoutWidth == 0) {
             //  Adding the magix here because we're using it in messageBubbleSizeForItemAtIndexPath
-            NSInteger sectionInset = layout.sectionInset.left + layout.sectionInset.right + [self magixInsetAddition];
+            NSInteger sectionInset = layout.sectionInset.left + layout.sectionInset.right + [self additionalInset];
             CGFloat width = CGRectGetWidth(layout.collectionView.bounds) - sectionInset;
             CGFloat height = CGRectGetHeight(layout.collectionView.bounds) - sectionInset;
             CGFloat minValue = MIN(width,height);

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
@@ -32,7 +32,7 @@
 
 @property (assign, nonatomic, readonly) NSUInteger minimumBubbleWidth;
 
-@property (assign, nonatomic, readonly) BOOL usesFixedWidthMessageBubbles;
+@property (assign, nonatomic, readonly) BOOL usesFixedWidthBubbles;
 
 @property (assign, nonatomic) NSInteger rotationIndependentLayoutWidth;
 
@@ -43,16 +43,18 @@
 
 #pragma mark - Init
 
-- (instancetype)initWithCache:(NSCache *)cache minimumBubbleWidth:(NSUInteger)minimumBubbleWidth usesFixedWidthMessageBubbles:(BOOL)fixedWidthMessageBubbles
+- (instancetype)initWithCache:(NSCache *)cache
+           minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
+        usesFixedWidthBubbles:(BOOL)fixedWidthBubbles
 {
     NSParameterAssert(cache != nil);
     NSParameterAssert(minimumBubbleWidth > 0);
-
+    
     self = [super init];
     if (self) {
         _cache = cache;
         _minimumBubbleWidth = minimumBubbleWidth;
-        _usesFixedWidthMessageBubbles = fixedWidthMessageBubbles;
+        _usesFixedWidthBubbles = fixedWidthBubbles;
     }
     return self;
 }
@@ -62,10 +64,9 @@
     NSCache *cache = [NSCache new];
     cache.name = @"JSQMessagesBubblesSizeCalculator.cache";
     cache.countLimit = 200;
-	return [self initWithCache:cache
-			minimumBubbleWidth:[UIImage jsq_bubbleCompactImage].size.width
-  usesFixedWidthMessageBubbles:NO
-			];
+    return [self initWithCache:cache
+            minimumBubbleWidth:[UIImage jsq_bubbleCompactImage].size.width
+         usesFixedWidthBubbles:NO];
 }
 
 #pragma mark - NSObject
@@ -153,18 +154,18 @@
     return 2;
 }
 
-- (CGFloat)textBubbleWidth:(JSQMessagesCollectionViewFlowLayout *)layout
+- (CGFloat)textBubbleWidthForLayout:(JSQMessagesCollectionViewFlowLayout *)layout
 {
-    if (_usesFixedWidthMessageBubbles) {
-        if (_rotationIndependentLayoutWidth == 0) {
+    if (self.usesFixedWidthBubbles) {
+        if (self.rotationIndependentLayoutWidth == 0) {
             //  Adding the magix here because we're using it in messageBubbleSizeForItemAtIndexPath
             NSInteger sectionInset = layout.sectionInset.left + layout.sectionInset.right + [self magixInsetAddition];
-            CGFloat width = CGRectGetWidth([(UICollectionView *)[layout collectionView] bounds]) - sectionInset;
-            CGFloat height = CGRectGetHeight([(UICollectionView *)[layout collectionView] bounds]) - sectionInset;
-            CGFloat minValue = (width<height)?width:height;
+            CGFloat width = CGRectGetWidth(layout.collectionView.bounds) - sectionInset;
+            CGFloat height = CGRectGetHeight(layout.collectionView.bounds) - sectionInset;
+            CGFloat minValue = MIN(width,height);
             _rotationIndependentLayoutWidth = minValue;
         }
-        return _rotationIndependentLayoutWidth;
+        return self.rotationIndependentLayoutWidth;
     }
     return layout.itemWidth;
 }

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
@@ -45,7 +45,7 @@
 
 - (instancetype)initWithCache:(NSCache *)cache
            minimumBubbleWidth:(NSUInteger)minimumBubbleWidth
-        usesFixedWidthBubbles:(BOOL)fixedWidthBubbles
+        usesFixedWidthBubbles:(BOOL)usesFixedWidthBubbles
 {
     NSParameterAssert(cache != nil);
     NSParameterAssert(minimumBubbleWidth > 0);
@@ -54,7 +54,7 @@
     if (self) {
         _cache = cache;
         _minimumBubbleWidth = minimumBubbleWidth;
-        _usesFixedWidthBubbles = fixedWidthBubbles;
+        _usesFixedWidthBubbles = usesFixedWidthBubbles;
     }
     return self;
 }

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
@@ -107,7 +107,7 @@
         CGFloat horizontalFrameInsets = layout.messageBubbleTextViewFrameInsets.left + layout.messageBubbleTextViewFrameInsets.right;
 
         CGFloat horizontalInsetsTotal = horizontalContainerInsets + horizontalFrameInsets + spacingBetweenAvatarAndBubble;
-        CGFloat maximumTextWidth = [self textBubbleWidth:layout] - avatarSize.width - layout.messageBubbleLeftRightMargin - horizontalInsetsTotal;
+        CGFloat maximumTextWidth = [self textBubbleWidthForLayout:layout] - avatarSize.width - layout.messageBubbleLeftRightMargin - horizontalInsetsTotal;
 
         CGRect stringRect = [[messageData text] boundingRectWithSize:CGSizeMake(maximumTextWidth, CGFLOAT_MAX)
                                                              options:(NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading)


### PR DESCRIPTION
The default behavior will be to use the old method (rotation-dependent bubble widths)
Relates to issue #1112