### PR TITLE
Support dynamic type

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -61,7 +61,7 @@
     self.scrollsToTop = NO;
     self.userInteractionEnabled = YES;
     
-    self.font = [UIFont systemFontOfSize:16.0f];
+    self.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     self.textColor = [UIColor blackColor];
     self.textAlignment = NSTextAlignmentNatural;
     

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
@@ -57,10 +57,11 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
     self.jsq_isObserving = NO;
     self.sendButtonOnRight = YES;
 
-    self.preferredDefaultHeight = 44.0f;
+    JSQMessagesToolbarContentView *toolbarContentView = [self loadToolbarContentView];
+    [toolbarContentView.textView sizeToFit];
+    self.preferredDefaultHeight = toolbarContentView.textView.frame.size.height + 16;
     self.maximumHeight = NSNotFound;
 
-    JSQMessagesToolbarContentView *toolbarContentView = [self loadToolbarContentView];
     toolbarContentView.frame = self.frame;
     [self addSubview:toolbarContentView];
     [self jsq_pinAllEdgesOfSubview:toolbarContentView];


### PR DESCRIPTION
This change supports dynamic type in the UITextView input area of JSQMessagesViewController. Presently dynamic type is only support in the Message Bubbles.