### PR TITLE
Fix for issue 1174

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -61,6 +61,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 @property (strong, nonatomic) NSIndexPath *selectedIndexPathForMenu;
 
+@property (weak, nonatomic) UIGestureRecognizer *currentInteractivePopGestureRecognizer;
+
 - (void)jsq_configureMessagesViewController;
 
 - (NSString *)jsq_currentlyComposedMessageText;
@@ -258,13 +260,13 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [self jsq_addActionToInteractivePopGestureRecognizer:NO];
     self.collectionView.collectionViewLayout.springinessEnabled = NO;
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];
+    [self jsq_addActionToInteractivePopGestureRecognizer:NO];
     [self jsq_removeObservers];
     [self.keyboardController endListeningForKeyboard];
 }
@@ -1038,14 +1040,15 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (void)jsq_addActionToInteractivePopGestureRecognizer:(BOOL)addAction
 {
-    if (self.navigationController.interactivePopGestureRecognizer) {
-        [self.navigationController.interactivePopGestureRecognizer removeTarget:nil
-                                                                         action:@selector(jsq_handleInteractivePopGestureRecognizer:)];
-        
-        if (addAction) {
-            [self.navigationController.interactivePopGestureRecognizer addTarget:self
-                                                                          action:@selector(jsq_handleInteractivePopGestureRecognizer:)];
-        }
+    if (_currentInteractivePopGestureRecognizer) {
+        [_currentInteractivePopGestureRecognizer removeTarget:nil
+                                                       action:@selector(jsq_handleInteractivePopGestureRecognizer:)];
+        _currentInteractivePopGestureRecognizer = nil;
+    }
+    if (addAction) {
+        [self.navigationController.interactivePopGestureRecognizer addTarget:self
+                                                                      action:@selector(jsq_handleInteractivePopGestureRecognizer:)];
+        _currentInteractivePopGestureRecognizer = self.navigationController.interactivePopGestureRecognizer;
     }
 }
 

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -1040,15 +1040,15 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 - (void)jsq_addActionToInteractivePopGestureRecognizer:(BOOL)addAction
 {
-    if (_currentInteractivePopGestureRecognizer) {
-        [_currentInteractivePopGestureRecognizer removeTarget:nil
+    if (self.currentInteractivePopGestureRecognizer) {
+        [self.currentInteractivePopGestureRecognizer removeTarget:nil
                                                        action:@selector(jsq_handleInteractivePopGestureRecognizer:)];
-        _currentInteractivePopGestureRecognizer = nil;
+        self.currentInteractivePopGestureRecognizer = nil;
     }
     if (addAction) {
         [self.navigationController.interactivePopGestureRecognizer addTarget:self
                                                                       action:@selector(jsq_handleInteractivePopGestureRecognizer:)];
-        _currentInteractivePopGestureRecognizer = self.navigationController.interactivePopGestureRecognizer;
+        self.currentInteractivePopGestureRecognizer = self.navigationController.interactivePopGestureRecognizer;
     }
 }
 


### PR DESCRIPTION
This avoids the problems mentioned in #1174 by removing our target on the Interactive Pop Gesture at viewDidDisappear-time
It avoid regressing to the problems documented in #257 by capturing the UIGestureRecognizer (as weak) at the time we addTarget. This allow us to remember on whom we should removeTarget.

I will have a separate commit to add a 2-level navigation-controller push to the Demo project (PR #1176), but that is not directly related to #1174 nor #257