### PR TITLE
Address #1174 & prevent inputToolbar-positioning regression

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -63,6 +63,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 @property (weak, nonatomic) UIGestureRecognizer *currentInteractivePopGestureRecognizer;
 
+@property (assign, nonatomic) BOOL interactivePopGestureFirstResponderState;
+
 - (void)jsq_configureMessagesViewController;
 
 - (NSString *)jsq_currentlyComposedMessageText;
@@ -260,13 +262,13 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 - (void)viewWillDisappear:(BOOL)animated
 {
     [super viewWillDisappear:animated];
-    [self jsq_addActionToInteractivePopGestureRecognizer:NO];
     self.collectionView.collectionViewLayout.springinessEnabled = NO;
 }
 
 - (void)viewDidDisappear:(BOOL)animated
 {
     [super viewDidDisappear:animated];
+    [self jsq_addActionToInteractivePopGestureRecognizer:NO];
     [self jsq_removeObservers];
     [self.keyboardController endListeningForKeyboard];
 }
@@ -844,6 +846,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
                 [self.snapshotView removeFromSuperview];
             }
 
+            _interactivePopGestureFirstResponderState = [[[[self inputToolbar] contentView] textView] isFirstResponder];
+
             [self.keyboardController endListeningForKeyboard];
 
             if ([UIDevice jsq_isCurrentDeviceBeforeiOS8]) {
@@ -865,6 +869,9 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
         case UIGestureRecognizerStateEnded:
         case UIGestureRecognizerStateFailed:
             [self.keyboardController beginListeningForKeyboard];
+            if (_interactivePopGestureFirstResponderState) {
+                [[[[self inputToolbar] contentView] textView] becomeFirstResponder];
+            }
 
             if ([UIDevice jsq_isCurrentDeviceBeforeiOS8]) {
                 [self.snapshotView removeFromSuperview];

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -63,7 +63,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 
 @property (weak, nonatomic) UIGestureRecognizer *currentInteractivePopGestureRecognizer;
 
-@property (assign, nonatomic) BOOL interactivePopGestureFirstResponderState;
+@property (assign, nonatomic) BOOL textViewWasFirstResponderDuringInteractivePop;
 
 - (void)jsq_configureMessagesViewController;
 
@@ -846,7 +846,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
                 [self.snapshotView removeFromSuperview];
             }
 
-            _interactivePopGestureFirstResponderState = [[[[self inputToolbar] contentView] textView] isFirstResponder];
+            self.textViewWasFirstResponderDuringInteractivePop = [self.inputToolbar.contentView.textView isFirstResponder];
 
             [self.keyboardController endListeningForKeyboard];
 
@@ -869,8 +869,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
         case UIGestureRecognizerStateEnded:
         case UIGestureRecognizerStateFailed:
             [self.keyboardController beginListeningForKeyboard];
-            if (_interactivePopGestureFirstResponderState) {
-                [[[[self inputToolbar] contentView] textView] becomeFirstResponder];
+            if (self.textViewWasFirstResponderDuringInteractivePop) {
+                [self.inputToolbar.contentView.textView becomeFirstResponder];
             }
 
             if ([UIDevice jsq_isCurrentDeviceBeforeiOS8]) {


### PR DESCRIPTION
Track the state of first-responder when the interactive pop gesture begins
Restore the first-responder state when pop gesture ends/cancels


This contains the main idea from PR #1175
- Moving "[self jsq_addActionToInteractivePopGestureRecognizer:NO];" to viewDidDisappear

But at the same time maintains the inputToolbar in the right position in the case of a interactive-pop cancel/failure.