### PR TITLE
Customizable isOutgoing

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -269,6 +269,15 @@
 - (void)scrollToBottomAnimated:(BOOL)animated;
 
 /**
+ * Used to decide if a message is incoming or outgoing.
+ *
+ * @discussion The default implementation of this method compares the `senderId` of the message to the
+ * value of the `senderId` property and returns `YES` if they are equal. Subclasses can override
+ * this method to specialize the decision logic.
+ */
+- (BOOL)isOutgoingMessage:(id<JSQMessageData>)messageItem;
+
+/**
  Call to super required.
  */
 - (void)viewDidLoad NS_REQUIRES_SUPER;

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -383,6 +383,14 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
                                         animated:animated];
 }
 
+- (BOOL)isOutgoingMessage:(id<JSQMessageData>)messageItem
+{
+    NSString *messageSenderId = [messageItem senderId];
+    NSParameterAssert(messageSenderId != nil);
+    
+    return [messageSenderId isEqualToString:self.senderId];
+}
+
 #pragma mark - JSQMessages collection view data source
 
 - (id<JSQMessageData>)collectionView:(JSQMessagesCollectionView *)collectionView messageDataForItemAtIndexPath:(NSIndexPath *)indexPath
@@ -439,11 +447,8 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 {
     id<JSQMessageData> messageItem = [collectionView.dataSource collectionView:collectionView messageDataForItemAtIndexPath:indexPath];
     NSParameterAssert(messageItem != nil);
-
-    NSString *messageSenderId = [messageItem senderId];
-    NSParameterAssert(messageSenderId != nil);
-
-    BOOL isOutgoingMessage = [messageSenderId isEqualToString:self.senderId];
+    
+    BOOL isOutgoingMessage = [self isOutgoingMessage:messageItem];
     BOOL isMediaMessage = [messageItem isMediaMessage];
 
     NSString *cellIdentifier = nil;


### PR DESCRIPTION
In some group chat scenarios (multi device chats, team chats) is makes sense to display the messages of more than on sender on the right. To do this, it's helpful to have a designated place to decide which messages should be considered outgoing i.e. on the right.