### PR TITLE
Swift 2.0 interoperability

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.h
@@ -24,6 +24,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesKeyboardController;
 
 /**
@@ -123,7 +125,7 @@ FOUNDATION_EXPORT NSString * const JSQMessagesKeyboardControllerUserInfoKeyKeybo
 - (instancetype)initWithTextView:(UITextView *)textView
                      contextView:(UIView *)contextView
             panGestureRecognizer:(UIPanGestureRecognizer *)panGestureRecognizer
-                        delegate:(id<JSQMessagesKeyboardControllerDelegate>)delegate;
+                        delegate:(nullable id<JSQMessagesKeyboardControllerDelegate>)delegate;
 
 /**
  *  Tells the keyboard controller that it should begin listening for system keyboard notifications.
@@ -136,3 +138,5 @@ FOUNDATION_EXPORT NSString * const JSQMessagesKeyboardControllerUserInfoKeyKeybo
 - (void)endListeningForKeyboard;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -194,9 +194,9 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @discussion This is the designated initializer for programmatic instantiation.
  *
- *  @return An initialized `JSQMessagesViewController` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesViewController` object.
  */
-+ (nullable instancetype)messagesViewController;
++ (instancetype)messagesViewController;
 
 #pragma mark - Messages view controller
 

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -23,6 +23,8 @@
 #import "JSQMessagesInputToolbar.h"
 #import "JSQMessagesKeyboardController.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  The `JSQMessagesViewController` class is an abstract class that represents a view controller whose content consists of
  *  a `JSQMessagesCollectionView` and `JSQMessagesInputToolbar` and is specialized to display a messaging interface.
@@ -32,6 +34,7 @@
 @interface JSQMessagesViewController : UIViewController <JSQMessagesCollectionViewDataSource,
                                                          JSQMessagesCollectionViewDelegateFlowLayout,
                                                          UITextViewDelegate>
+
 
 /**
  *  Returns the collection view object managed by this view controller.
@@ -184,7 +187,7 @@
  *  you should also override `messagesViewController` to return your
  *  view controller loaded from your custom nib.
  */
-+ (UINib *)nib;
++ (nullable UINib *)nib;
 
 /**
  *  Creates and returns a new `JSQMessagesViewController` object.
@@ -193,7 +196,7 @@
  *
  *  @return An initialized `JSQMessagesViewController` object if successful, `nil` otherwise.
  */
-+ (instancetype)messagesViewController;
++ (nullable instancetype)messagesViewController;
 
 #pragma mark - Messages view controller
 
@@ -269,3 +272,5 @@
 - (void)scrollToBottomAnimated:(BOOL)animated;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -37,13 +37,13 @@
  *  Returns the collection view object managed by this view controller.
  *  This view controller is the collection view's data source and delegate.
  */
-@property (weak, nonatomic, readonly) JSQMessagesCollectionView *collectionView;
+@property (nonatomic, readonly) JSQMessagesCollectionView *collectionView;
 
 /**
  *  Returns the input toolbar view object managed by this view controller.
  *  This view controller is the toolbar's delegate.
  */
-@property (weak, nonatomic, readonly) JSQMessagesInputToolbar *inputToolbar;
+@property (nonatomic, readonly) JSQMessagesInputToolbar *inputToolbar;
 
 /**
  *  Returns the keyboard controller object used to manage the software keyboard.

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -49,11 +49,11 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
 @interface JSQMessagesViewController () <JSQMessagesInputToolbarDelegate,
                                          JSQMessagesKeyboardControllerDelegate>
 
-@property (weak, nonatomic) IBOutlet JSQMessagesCollectionView *collectionView;
-@property (weak, nonatomic) IBOutlet JSQMessagesInputToolbar *inputToolbar;
+@property (nonatomic) IBOutlet JSQMessagesCollectionView *collectionView;
+@property (nonatomic) IBOutlet JSQMessagesInputToolbar *inputToolbar;
 
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *toolbarHeightConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *toolbarBottomLayoutGuide;
+@property (nonatomic) IBOutlet NSLayoutConstraint *toolbarHeightConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *toolbarBottomLayoutGuide;
 
 @property (weak, nonatomic) UIView *snapshotView;
 

--- a/JSQMessagesViewController/Factories/JSQMessagesAvatarImageFactory.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesAvatarImageFactory.h
@@ -21,6 +21,8 @@
 
 #import "JSQMessagesAvatarImage.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  `JSQMessagesAvatarImageFactory` is a factory that provides a means for creating and styling
  *  `JSQMessagesAvatarImage` objects to be displayed in a `JSQMessagesCollectionViewCell` of a `JSQMessagesCollectionView`.
@@ -34,7 +36,7 @@
 *  @param placeholderImage An image object that represents a placeholder avatar image. This value must not be `nil`.
 *  @param diameter         An integer value specifying the diameter size of the avatar in points. This value must be greater than `0`.
 *
-*  @return An initialized `JSQMessagesAvatarImage` object if created successfully, `nil` otherwise.
+*  @return An initialized `JSQMessagesAvatarImage` object.
 */
 + (JSQMessagesAvatarImage *)avatarImageWithPlaceholder:(UIImage *)placeholderImage diameter:(NSUInteger)diameter;
 
@@ -47,7 +49,7 @@
  *  @param image    An image object that represents an avatar image. This value must not be `nil`.
  *  @param diameter An integer value specifying the diameter size of the avatar in points. This value must be greater than `0`.
  *
- *  @return An initialized `JSQMessagesAvatarImage` object if created successfully, `nil` otherwise.
+ *  @return An initialized `JSQMessagesAvatarImage` object.
  */
 + (JSQMessagesAvatarImage *)avatarImageWithImage:(UIImage *)image diameter:(NSUInteger)diameter;
 
@@ -57,7 +59,7 @@
  *  @param image    The image to crop. This value must not be `nil`.
  *  @param diameter An integer value specifying the diameter size of the image in points. This value must be greater than `0`.
  *
- *  @return A new image object if successful, `nil` otherwise.
+ *  @return A new image object.
  */
 + (UIImage *)circularAvatarImage:(UIImage *)image withDiameter:(NSUInteger)diameter;
 
@@ -68,7 +70,7 @@
  *  @param image    The image to crop. This value must not be `nil`.
  *  @param diameter An integer value specifying the diameter size of the image in points. This value must be greater than `0`.
  *
- *  @return A new image object if successful, `nil` otherwise.
+ *  @return A new image object.
  */
 + (UIImage *)circularAvatarHighlightedImage:(UIImage *)image withDiameter:(NSUInteger)diameter;
 
@@ -82,7 +84,7 @@
  *  @param font            The font applied to userInitials. This value must not be `nil`.
  *  @param diameter        The diameter of the avatar image. This value must be greater than `0`.
  *
- *  @return An initialized `JSQMessagesAvatarImage` object if created successfully, `nil` otherwise.
+ *  @return An initialized `JSQMessagesAvatarImage` object.
  *
  *  @discussion This method does not attempt to detect or correct incompatible parameters. 
  *  That is to say, you are responsible for providing a font size and diameter that make sense.
@@ -97,3 +99,5 @@
                                                diameter:(NSUInteger)diameter;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Factories/JSQMessagesBubbleImageFactory.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesBubbleImageFactory.h
@@ -21,6 +21,8 @@
 
 #import "JSQMessagesBubbleImage.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  `JSQMessagesBubbleImageFactory` is a factory that provides a means for creating and styling 
  *  `JSQMessagesBubbleImage` objects to be displayed in a `JSQMessagesCollectionViewCell` of a `JSQMessagesCollectionView`.
@@ -31,7 +33,7 @@
  *  Creates and returns a new instance of `JSQMessagesBubbleImageFactory` that uses the
  *  default bubble image assets and cap insets.
  *
- *  @return An initialized `JSQMessagesBubbleImageFactory` object if created successfully, `nil` otherwise.
+ *  @return An initialized `JSQMessagesBubbleImageFactory` object.
  */
 - (instancetype)init;
 
@@ -47,7 +49,7 @@
  *  @param capInsets   The values to use for the cap insets that define the unstretchable regions of the image.
  *  Specify `UIEdgeInsetsZero` to have the factory create insets that allow the image to stretch from its center point.
  *
- *  @return An initialized `JSQMessagesBubbleImageFactory` object if created successfully, `nil` otherwise.
+ *  @return An initialized `JSQMessagesBubbleImageFactory` object.
  */
 - (instancetype)initWithBubbleImage:(UIImage *)bubbleImage capInsets:(UIEdgeInsets)capInsets;
 
@@ -58,7 +60,7 @@
  *
  *  @param color The color of the bubble image in the image view. This value must not be `nil`.
  *
- *  @return An initialized `JSQMessagesBubbleImage` object if created successfully, `nil` otherwise.
+ *  @return An initialized `JSQMessagesBubbleImage` object.
  */
 - (JSQMessagesBubbleImage *)outgoingMessagesBubbleImageWithColor:(UIColor *)color;
 
@@ -69,8 +71,10 @@
  *
  *  @param color The color of the bubble image in the image view. This value must not be `nil`.
  *
- *  @return An initialized `JSQMessagesBubbleImage` object if created successfully, `nil` otherwise.
+ *  @return An initialized `JSQMessagesBubbleImage` object.
  */
 - (JSQMessagesBubbleImage *)incomingMessagesBubbleImageWithColor:(UIColor *)color;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Factories/JSQMessagesMediaViewBubbleImageMasker.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesMediaViewBubbleImageMasker.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesBubbleImageFactory;
 
 /**
@@ -88,3 +90,5 @@
 + (void)applyBubbleImageMaskToMediaView:(UIView *)mediaView isOutgoing:(BOOL)isOutgoing;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  `JSQMessagesToolbarButtonFactory` is a factory that provides a means for creating the default
  *  toolbar button items to be displayed in the content view of a `JSQMessagesInputToolbar`.
@@ -42,3 +44,5 @@
 + (UIButton *)defaultSendButtonItem;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.h
@@ -25,6 +25,8 @@
 
 #import "JSQMessagesBubbleSizeCalculating.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesCollectionView;
 
 
@@ -211,3 +213,5 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault;
 - (CGSize)sizeForItemAtIndexPath:(NSIndexPath *)indexPath;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayoutInvalidationContext.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayoutInvalidationContext.h
@@ -42,6 +42,6 @@
  *
  *  @return An initialized invalidation context object if successful, otherwise `nil`.
  */
-+ (instancetype)context;
++ (nullable instancetype)context;
 
 @end

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayoutInvalidationContext.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayoutInvalidationContext.h
@@ -40,8 +40,8 @@
  *  `JSQMessagesViewController` subclass, you should use this method to instantiate a new invalidation 
  *  context and pass this object to `invalidateLayoutWithContext:`.
  *
- *  @return An initialized invalidation context object if successful, otherwise `nil`.
+ *  @return An initialized invalidation context object.
  */
-+ (nullable instancetype)context;
++ (instancetype)context;
 
 @end

--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewLayoutAttributes.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewLayoutAttributes.h
@@ -28,7 +28,7 @@
  *  The font used to display the body of a text message in a message bubble within a `JSQMessagesCollectionViewCell`.
  *  This value must not be `nil`.
  */
-@property (strong, nonatomic) UIFont *messageBubbleFont;
+@property (nonnull, strong, nonatomic) UIFont *messageBubbleFont;
 
 /**
  *  The width of the `messageBubbleContainerView` of a `JSQMessagesCollectionViewCell`.

--- a/JSQMessagesViewController/Model/JSQMessage.h
+++ b/JSQMessagesViewController/Model/JSQMessage.h
@@ -20,6 +20,8 @@
 
 #import "JSQMessageData.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  The `JSQMessage` class is a concrete class for message model objects that represents a single user message.
  *  The message can be a text message or media message, depending on how it is initialized.
@@ -55,13 +57,13 @@
  *  Returns the body text of the message, or `nil` if the message is a media message.
  *  That is, if `isMediaMessage` is equal to `YES` then this value will be `nil`.
  */
-@property (copy, nonatomic, readonly) NSString *text;
+@property (nullable, copy, nonatomic, readonly) NSString *text;
 
 /**
  *  Returns the media item attachment of the message, or `nil` if the message is not a media message.
  *  That is, if `isMediaMessage` is equal to `NO` then this value will be `nil`.
  */
-@property (copy, nonatomic, readonly) id<JSQMessageMediaData> media;
+@property (nullable, copy, nonatomic, readonly) id<JSQMessageMediaData> media;
 
 
 #pragma mark - Initialization
@@ -78,9 +80,9 @@
  *
  *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
  */
-+ (instancetype)messageWithSenderId:(NSString *)senderId
-                        displayName:(NSString *)displayName
-                               text:(NSString *)text;
++ (nullable instancetype)messageWithSenderId:(NSString *)senderId
+                                 displayName:(NSString *)displayName
+                                        text:(NSString *)text;
 
 /**
  *  Initializes and returns a message object having the given senderId, senderDisplayName, date, and text.
@@ -94,10 +96,10 @@
  *
  *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
  */
-- (instancetype)initWithSenderId:(NSString *)senderId
-               senderDisplayName:(NSString *)senderDisplayName
-                            date:(NSDate *)date
-                            text:(NSString *)text;
+- (nullable instancetype)initWithSenderId:(NSString *)senderId
+                        senderDisplayName:(NSString *)senderDisplayName
+                                     date:(NSDate *)date
+                                     text:(NSString *)text;
 /**
  *  Initializes and returns a message object having the given senderId, displayName, media,
  *  and current system date.
@@ -110,9 +112,9 @@
  *
  *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
  */
-+ (instancetype)messageWithSenderId:(NSString *)senderId
-                        displayName:(NSString *)displayName
-                              media:(id<JSQMessageMediaData>)media;
++ (nullable instancetype)messageWithSenderId:(NSString *)senderId
+                                 displayName:(NSString *)displayName
+                                       media:(id<JSQMessageMediaData>)media;
 
 /**
  *  Initializes and returns a message object having the given senderId, displayName, date, and media.
@@ -126,9 +128,11 @@
  *
  *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
  */
-- (instancetype)initWithSenderId:(NSString *)senderId
-               senderDisplayName:(NSString *)senderDisplayName
-                            date:(NSDate *)date
-                           media:(id<JSQMessageMediaData>)media;
+- (nullable instancetype)initWithSenderId:(NSString *)senderId
+                        senderDisplayName:(NSString *)senderDisplayName
+                                     date:(NSDate *)date
+                                    media:(id<JSQMessageMediaData>)media;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Model/JSQMessage.h
+++ b/JSQMessagesViewController/Model/JSQMessage.h
@@ -78,11 +78,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `NO`.
  *
- *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessage` object.
  */
-+ (nullable instancetype)messageWithSenderId:(NSString *)senderId
-                                 displayName:(NSString *)displayName
-                                        text:(NSString *)text;
++ (instancetype)messageWithSenderId:(NSString *)senderId
+                        displayName:(NSString *)displayName
+                               text:(NSString *)text;
 
 /**
  *  Initializes and returns a message object having the given senderId, senderDisplayName, date, and text.
@@ -94,12 +94,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `NO`.
  *
- *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessage` object.
  */
-- (nullable instancetype)initWithSenderId:(NSString *)senderId
-                        senderDisplayName:(NSString *)senderDisplayName
-                                     date:(NSDate *)date
-                                     text:(NSString *)text;
+- (instancetype)initWithSenderId:(NSString *)senderId
+               senderDisplayName:(NSString *)senderDisplayName
+                            date:(NSDate *)date
+                            text:(NSString *)text;
 /**
  *  Initializes and returns a message object having the given senderId, displayName, media,
  *  and current system date.
@@ -110,11 +110,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `YES`.
  *
- *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessage` object.
  */
-+ (nullable instancetype)messageWithSenderId:(NSString *)senderId
-                                 displayName:(NSString *)displayName
-                                       media:(id<JSQMessageMediaData>)media;
++ (instancetype)messageWithSenderId:(NSString *)senderId
+                        displayName:(NSString *)displayName
+                              media:(id<JSQMessageMediaData>)media;
 
 /**
  *  Initializes and returns a message object having the given senderId, displayName, date, and media.
@@ -126,12 +126,12 @@ NS_ASSUME_NONNULL_BEGIN
  *
  *  @discussion Initializing a `JSQMessage` with this method will set `isMediaMessage` to `YES`.
  *
- *  @return An initialized `JSQMessage` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessage` object.
  */
-- (nullable instancetype)initWithSenderId:(NSString *)senderId
-                        senderDisplayName:(NSString *)senderDisplayName
-                                     date:(NSDate *)date
-                                    media:(id<JSQMessageMediaData>)media;
+- (instancetype)initWithSenderId:(NSString *)senderId
+               senderDisplayName:(NSString *)senderDisplayName
+                            date:(NSDate *)date
+                           media:(id<JSQMessageMediaData>)media;
 
 @end
 

--- a/JSQMessagesViewController/Model/JSQMessageAvatarImageDataSource.h
+++ b/JSQMessagesViewController/Model/JSQMessageAvatarImageDataSource.h
@@ -39,14 +39,14 @@
  *  
  *  @discussion You may return `nil` from this method while the image is being downloaded.
  */
-- (UIImage *)avatarImage;
+- (nullable UIImage *)avatarImage;
 
 /**
  *  @return The avatar image for a highlighted display state. 
  *  
  *  @discussion You may return `nil` from this method if this does not apply.
  */
-- (UIImage *)avatarHighlightedImage;
+- (nullable UIImage *)avatarHighlightedImage;
 
 /**
  *  @return A placeholder avatar image to be displayed if avatarImage is not yet available, or `nil`.
@@ -58,6 +58,6 @@
  *
  *  @warning You must not return `nil` from this method.
  */
-- (UIImage *)avatarPlaceholderImage;
+- (nonnull UIImage *)avatarPlaceholderImage;
 
 @end

--- a/JSQMessagesViewController/Model/JSQMessageData.h
+++ b/JSQMessagesViewController/Model/JSQMessageData.h
@@ -20,6 +20,8 @@
 
 #import "JSQMessageMediaData.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  The `JSQMessageData` protocol defines the common interface through which 
  *  a `JSQMessagesViewController` and `JSQMessagesCollectionView` interact with message model objects.
@@ -86,15 +88,17 @@
 /**
  *  @return The body text of the message.
  *
- *  @warning You must not return `nil` from this method.
+ *  @warning You must not return `nil` from this method (if message is NOT a media item).
  */
-- (NSString *)text;
+- (nullable NSString *)text;
 
 /**
  *  @return The media item of the message.
  *  
- *  @warning You must not return `nil` from this method.
+ *  @warning You must not return `nil` from this method (if message is a media item).
  */
-- (id<JSQMessageMediaData>)media;
+- (nullable id<JSQMessageMediaData>)media;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Model/JSQMessageMediaData.h
+++ b/JSQMessagesViewController/Model/JSQMessageMediaData.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  The `JSQMessageMediaData` protocol defines the common interface through which
  *  a `JSQMessagesViewController` and `JSQMessagesCollectionView` interact with media message model objects.
@@ -43,7 +45,7 @@
  *
  *  @discussion You may return `nil` from this method while the media data is being downloaded.
  */
-- (UIView *)mediaView;
+- (nullable UIView *)mediaView;
 
 /**
  *  @return The frame size for the mediaView when displayed in a `JSQMessagesCollectionViewCell`. 
@@ -79,3 +81,5 @@
 - (NSUInteger)mediaHash;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Model/JSQMessagesAvatarImage.h
+++ b/JSQMessagesViewController/Model/JSQMessagesAvatarImage.h
@@ -21,6 +21,8 @@
 
 #import "JSQMessageAvatarImageDataSource.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  A `JSQMessagesAvatarImage` model object represents an avatar image.
  *  This is a concrete class that implements the `JSQMessageAvatarImageDataSource` protocol.
@@ -33,12 +35,12 @@
 /**
  *  The avatar image for a regular display state.
  */
-@property (nonatomic, strong) UIImage *avatarImage;
+@property (nullable, nonatomic, strong) UIImage *avatarImage;
 
 /**
  *  The avatar image for a highlighted display state.
  */
-@property (nonatomic, strong) UIImage *avatarHighlightedImage;
+@property (nullable, nonatomic, strong) UIImage *avatarHighlightedImage;
 
 /**
  *  Returns the placeholder image for an avatar to display if avatarImage is `nil`.
@@ -54,7 +56,7 @@
  *
  *  @return An initialized `JSQMessagesAvatarImage` object if successful, `nil` otherwise.
  */
-+ (instancetype)avatarWithImage:(UIImage *)image;
++ (nullable instancetype)avatarWithImage:(UIImage *)image;
 
 /**
  *  Initializes and returns an avatar image object having the specified placeholder image.
@@ -63,7 +65,7 @@
  *
  *  @return An initialized `JSQMessagesAvatarImage` object if successful, `nil` otherwise.
  */
-+ (instancetype)avatarImageWithPlaceholder:(UIImage *)placeholderImage;
++ (nullable instancetype)avatarImageWithPlaceholder:(UIImage *)placeholderImage;
 
 /**
  *  Initializes and returns an avatar image object having the specified regular, highlighed, and placeholder images.
@@ -74,8 +76,10 @@
  *
  *  @return An initialized `JSQMessagesAvatarImage` object if successful, `nil` otherwise.
  */
-- (instancetype)initWithAvatarImage:(UIImage *)avatarImage
-                   highlightedImage:(UIImage *)highlightedImage
-                   placeholderImage:(UIImage *)placeholderImage;
+- (nullable instancetype)initWithAvatarImage:(nullable UIImage *)avatarImage
+                            highlightedImage:(nullable UIImage *)highlightedImage
+                            placeholderImage:(UIImage *)placeholderImage;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Model/JSQMessagesAvatarImage.h
+++ b/JSQMessagesViewController/Model/JSQMessagesAvatarImage.h
@@ -54,18 +54,18 @@ NS_ASSUME_NONNULL_BEGIN
  *  properties: avatarImage, avatarHighlightedImage, avatarPlaceholderImage;
  *  This value must not be `nil`.
  *
- *  @return An initialized `JSQMessagesAvatarImage` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesAvatarImage` object.
  */
-+ (nullable instancetype)avatarWithImage:(UIImage *)image;
++ (instancetype)avatarWithImage:(UIImage *)image;
 
 /**
  *  Initializes and returns an avatar image object having the specified placeholder image.
  *
  *  @param placeholderImage The placeholder image for this avatar image. This value must not be `nil`.
  *
- *  @return An initialized `JSQMessagesAvatarImage` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesAvatarImage` object.
  */
-+ (nullable instancetype)avatarImageWithPlaceholder:(UIImage *)placeholderImage;
++ (instancetype)avatarImageWithPlaceholder:(UIImage *)placeholderImage;
 
 /**
  *  Initializes and returns an avatar image object having the specified regular, highlighed, and placeholder images.
@@ -74,11 +74,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param highlightedImage The avatar image for a highlighted display state.
  *  @param placeholderImage The placeholder image for this avatar image. This value must not be `nil`.
  *
- *  @return An initialized `JSQMessagesAvatarImage` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesAvatarImage` object.
  */
-- (nullable instancetype)initWithAvatarImage:(nullable UIImage *)avatarImage
-                            highlightedImage:(nullable UIImage *)highlightedImage
-                            placeholderImage:(UIImage *)placeholderImage;
+- (instancetype)initWithAvatarImage:(nullable UIImage *)avatarImage
+                   highlightedImage:(nullable UIImage *)highlightedImage
+                   placeholderImage:(UIImage *)placeholderImage;
 
 @end
 

--- a/JSQMessagesViewController/Model/JSQMessagesBubbleImage.h
+++ b/JSQMessagesViewController/Model/JSQMessagesBubbleImage.h
@@ -48,11 +48,11 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param image            The regular message bubble image. This value must not be `nil`.
  *  @param highlightedImage The highlighted message bubble image. This value must not be `nil`.
  *
- *  @return An initialized `JSQMessagesBubbleImage` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesBubbleImage` object.
  *
  *  @see JSQMessagesBubbleImageFactory.
  */
-- (nullable instancetype)initWithMessageBubbleImage:(UIImage *)image highlightedImage:(UIImage *)highlightedImage;
+- (instancetype)initWithMessageBubbleImage:(UIImage *)image highlightedImage:(UIImage *)highlightedImage;
 
 @end
 

--- a/JSQMessagesViewController/Model/JSQMessagesBubbleImage.h
+++ b/JSQMessagesViewController/Model/JSQMessagesBubbleImage.h
@@ -21,6 +21,8 @@
 
 #import "JSQMessageBubbleImageDataSource.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  A `JSQMessagesBubbleImage` model object represents a message bubble image, and is immutable. 
  *  This is a concrete class that implements the `JSQMessageBubbleImageDataSource` protocol.
@@ -50,6 +52,8 @@
  *
  *  @see JSQMessagesBubbleImageFactory.
  */
-- (instancetype)initWithMessageBubbleImage:(UIImage *)image highlightedImage:(UIImage *)highlightedImage;
+- (nullable instancetype)initWithMessageBubbleImage:(UIImage *)image highlightedImage:(UIImage *)highlightedImage;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Model/JSQMessagesCollectionViewDataSource.h
+++ b/JSQMessagesViewController/Model/JSQMessagesCollectionViewDataSource.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesCollectionView;
 @protocol JSQMessageData;
 @protocol JSQMessageBubbleImageDataSource;
@@ -89,7 +91,7 @@
  *  @see JSQMessagesBubbleImageFactory.
  *  @see JSQMessagesCollectionViewFlowLayout.
  */
-- (id<JSQMessageBubbleImageDataSource>)collectionView:(JSQMessagesCollectionView *)collectionView messageBubbleImageDataForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (nullable id<JSQMessageBubbleImageDataSource>)collectionView:(JSQMessagesCollectionView *)collectionView messageBubbleImageDataForItemAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
  *  Asks the data source for the avatar image data that corresponds to the specified message data item at indexPath in the collectionView.
@@ -106,7 +108,7 @@
  *  @see JSQMessagesAvatarImageFactory.
  *  @see JSQMessagesCollectionViewFlowLayout.
  */
-- (id<JSQMessageAvatarImageDataSource>)collectionView:(JSQMessagesCollectionView *)collectionView avatarImageDataForItemAtIndexPath:(NSIndexPath *)indexPath;
+- (nullable id<JSQMessageAvatarImageDataSource>)collectionView:(JSQMessagesCollectionView *)collectionView avatarImageDataForItemAtIndexPath:(NSIndexPath *)indexPath;
 
 @optional
 
@@ -122,7 +124,7 @@
  *
  *  @see JSQMessagesCollectionViewCell.
  */
-- (NSAttributedString *)collectionView:(JSQMessagesCollectionView *)collectionView attributedTextForCellTopLabelAtIndexPath:(NSIndexPath *)indexPath;
+- (nullable NSAttributedString *)collectionView:(JSQMessagesCollectionView *)collectionView attributedTextForCellTopLabelAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
  *  Asks the data source for the text to display in the `messageBubbleTopLabel` for the specified
@@ -136,7 +138,7 @@
  *
  *  @see JSQMessagesCollectionViewCell.
  */
-- (NSAttributedString *)collectionView:(JSQMessagesCollectionView *)collectionView attributedTextForMessageBubbleTopLabelAtIndexPath:(NSIndexPath *)indexPath;
+- (nullable NSAttributedString *)collectionView:(JSQMessagesCollectionView *)collectionView attributedTextForMessageBubbleTopLabelAtIndexPath:(NSIndexPath *)indexPath;
 
 /**
  *  Asks the data source for the text to display in the `cellBottomLabel` for the the specified
@@ -150,6 +152,8 @@
  *
  *  @see JSQMessagesCollectionViewCell.
  */
-- (NSAttributedString *)collectionView:(JSQMessagesCollectionView *)collectionView attributedTextForCellBottomLabelAtIndexPath:(NSIndexPath *)indexPath;
+- (nullable NSAttributedString *)collectionView:(JSQMessagesCollectionView *)collectionView attributedTextForCellBottomLabelAtIndexPath:(NSIndexPath *)indexPath;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Model/JSQMessagesCollectionViewDelegateFlowLayout.h
+++ b/JSQMessagesViewController/Model/JSQMessagesCollectionViewDelegateFlowLayout.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesCollectionView;
 @class JSQMessagesCollectionViewFlowLayout;
 @class JSQMessagesCollectionViewCell;
@@ -120,3 +122,6 @@
                 header:(JSQMessagesLoadEarlierHeaderView *)headerView didTapLoadEarlierMessagesButton:(UIButton *)sender;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.h
@@ -27,6 +27,8 @@
 @class JSQMessagesLoadEarlierHeaderView;
 
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  The `JSQMessagesCollectionView` class manages an ordered collection of message data items and presents
  *  them using a specialized layout for messages.
@@ -99,3 +101,6 @@
 - (JSQMessagesLoadEarlierHeaderView *)dequeueLoadEarlierMessagesViewHeaderForIndexPath:(NSIndexPath *)indexPath;
 
 @end
+
+NS_ASSUME_NONNULL_END
+

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
@@ -96,33 +96,33 @@
  *  Returns the label that is pinned to the top of the cell.
  *  This label is most commonly used to display message timestamps.
  */
-@property (weak, nonatomic, readonly) JSQMessagesLabel *cellTopLabel;
+@property (nonatomic, readonly) JSQMessagesLabel *cellTopLabel;
 
 /**
  *  Returns the label that is pinned just above the messageBubbleImageView, and below the cellTopLabel.
  *  This label is most commonly used to display the message sender.
  */
-@property (weak, nonatomic, readonly) JSQMessagesLabel *messageBubbleTopLabel;
+@property (nonatomic, readonly) JSQMessagesLabel *messageBubbleTopLabel;
 
 /**
  *  Returns the label that is pinned to the bottom of the cell.
  *  This label is most commonly used to display message delivery status.
  */
-@property (weak, nonatomic, readonly) JSQMessagesLabel *cellBottomLabel;
+@property (nonatomic, readonly) JSQMessagesLabel *cellBottomLabel;
 
 /**
  *  Returns the text view of the cell. This text view contains the message body text.
  *
  *  @warning If mediaView returns a non-nil view, then this value will be `nil`.
  */
-@property (weak, nonatomic, readonly) JSQMessagesCellTextView *textView;
+@property (nonatomic, readonly) JSQMessagesCellTextView *textView;
 
 /**
  *  Returns the bubble image view of the cell that is responsible for displaying message bubble images.
  *
  *  @warning If mediaView returns a non-nil view, then this value will be `nil`.
  */
-@property (weak, nonatomic, readonly) UIImageView *messageBubbleImageView;
+@property (nonatomic, readonly) UIImageView *messageBubbleImageView;
 
 /**
  *  Returns the message bubble container view of the cell. This view is the superview of
@@ -135,12 +135,12 @@
  *  its frame, nor should you remove this view from the cell or remove any of its subviews.
  *  Doing so could result in unexpected behavior.
  */
-@property (weak, nonatomic, readonly) UIView *messageBubbleContainerView;
+@property (nonatomic, readonly) UIView *messageBubbleContainerView;
 
 /**
  *  Returns the avatar image view of the cell that is responsible for displaying avatar images.
  */
-@property (weak, nonatomic, readonly) UIImageView *avatarImageView;
+@property (nonatomic, readonly) UIImageView *avatarImageView;
 
 /**
  *  Returns the avatar container view of the cell. This view is the superview of the cell's avatarImageView.
@@ -152,14 +152,14 @@
  *  its frame, nor should you remove this view from the cell or remove any of its subviews.
  *  Doing so could result in unexpected behavior.
  */
-@property (weak, nonatomic, readonly) UIView *avatarContainerView;
+@property (nonatomic, readonly) UIView *avatarContainerView;
 
 /**
  *  The media view of the cell. This view displays the contents of a media message.
  *
  *  @warning If this value is non-nil, then textView and messageBubbleImageView will both be `nil`.
  */
-@property (weak, nonatomic) UIView *mediaView;
+@property (nonatomic) UIView *mediaView;
 
 /**
  *  Returns the underlying gesture recognizer for tap gestures in the avatarImageView of the cell.

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.h
@@ -21,6 +21,8 @@
 #import "JSQMessagesLabel.h"
 #import "JSQMessagesCellTextView.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesCollectionViewCell;
 
 /**
@@ -115,14 +117,14 @@
  *
  *  @warning If mediaView returns a non-nil view, then this value will be `nil`.
  */
-@property (nonatomic, readonly) JSQMessagesCellTextView *textView;
+@property (nullable, nonatomic, readonly) JSQMessagesCellTextView *textView;
 
 /**
  *  Returns the bubble image view of the cell that is responsible for displaying message bubble images.
  *
  *  @warning If mediaView returns a non-nil view, then this value will be `nil`.
  */
-@property (nonatomic, readonly) UIImageView *messageBubbleImageView;
+@property (nullable, nonatomic, readonly) UIImageView *messageBubbleImageView;
 
 /**
  *  Returns the message bubble container view of the cell. This view is the superview of
@@ -159,7 +161,7 @@
  *
  *  @warning If this value is non-nil, then textView and messageBubbleImageView will both be `nil`.
  */
-@property (nonatomic) UIView *mediaView;
+@property (nullable, nonatomic) UIView *mediaView;
 
 /**
  *  Returns the underlying gesture recognizer for tap gestures in the avatarImageView of the cell.
@@ -175,7 +177,7 @@
  *  @return The initialized `UINib` object or `nil` if there were errors during
  *  initialization or the nib file could not be located.
  */
-+ (UINib *)nib;
++ (nullable UINib *)nib;
 
 /**
  *  Returns the default string used to identify a reusable cell for text message items.
@@ -204,3 +206,5 @@
 + (void)registerMenuAction:(SEL)action;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -31,30 +31,30 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 
 @interface JSQMessagesCollectionViewCell ()
 
-@property (weak, nonatomic) IBOutlet JSQMessagesLabel *cellTopLabel;
-@property (weak, nonatomic) IBOutlet JSQMessagesLabel *messageBubbleTopLabel;
-@property (weak, nonatomic) IBOutlet JSQMessagesLabel *cellBottomLabel;
+@property (nonatomic) IBOutlet JSQMessagesLabel *cellTopLabel;
+@property (nonatomic) IBOutlet JSQMessagesLabel *messageBubbleTopLabel;
+@property (nonatomic) IBOutlet JSQMessagesLabel *cellBottomLabel;
 
-@property (weak, nonatomic) IBOutlet UIView *messageBubbleContainerView;
-@property (weak, nonatomic) IBOutlet UIImageView *messageBubbleImageView;
-@property (weak, nonatomic) IBOutlet JSQMessagesCellTextView *textView;
+@property (nonatomic) IBOutlet UIView *messageBubbleContainerView;
+@property (nonatomic) IBOutlet UIImageView *messageBubbleImageView;
+@property (nonatomic) IBOutlet JSQMessagesCellTextView *textView;
 
-@property (weak, nonatomic) IBOutlet UIImageView *avatarImageView;
-@property (weak, nonatomic) IBOutlet UIView *avatarContainerView;
+@property (nonatomic) IBOutlet UIImageView *avatarImageView;
+@property (nonatomic) IBOutlet UIView *avatarContainerView;
 
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageBubbleContainerWidthConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *messageBubbleContainerWidthConstraint;
 
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *textViewTopVerticalSpaceConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *textViewBottomVerticalSpaceConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *textViewAvatarHorizontalSpaceConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *textViewMarginHorizontalSpaceConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *textViewTopVerticalSpaceConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *textViewBottomVerticalSpaceConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *textViewAvatarHorizontalSpaceConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *textViewMarginHorizontalSpaceConstraint;
 
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *cellTopLabelHeightConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *messageBubbleTopLabelHeightConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *cellBottomLabelHeightConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *cellTopLabelHeightConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *messageBubbleTopLabelHeightConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *cellBottomLabelHeightConstraint;
 
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *avatarContainerViewWidthConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *avatarContainerViewHeightConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *avatarContainerViewWidthConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *avatarContainerViewHeightConstraint;
 
 @property (assign, nonatomic) UIEdgeInsets textViewFrameInsets;
 

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
@@ -18,6 +18,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesComposerTextView;
 
 /**
@@ -45,7 +47,7 @@
 /**
  *  The text to be displayed when the text view is empty. The default value is `nil`.
  */
-@property (copy, nonatomic) NSString *placeHolder;
+@property (nullable, copy, nonatomic) NSString *placeHolder;
 
 /**
  *  The color of the place holder text. The default value is `[UIColor lightGrayColor]`.
@@ -66,3 +68,5 @@
 - (BOOL)hasText;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
@@ -67,7 +67,7 @@
 /**
  *  Returns the content view of the toolbar. This view contains all subviews of the toolbar.
  */
-@property (weak, nonatomic, readonly) JSQMessagesToolbarContentView *contentView;
+@property (nonatomic, readonly) JSQMessagesToolbarContentView *contentView;
 
 /**
  *  A boolean value indicating whether the send button is on the right side of the toolbar or not.

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.h
@@ -21,6 +21,8 @@
 
 #import "JSQMessagesToolbarContentView.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesInputToolbar;
 
 
@@ -105,6 +107,8 @@
  *
  *  @return An initialized `JSQMessagesToolbarContentView` if successful, otherwise `nil`.
  */
-- (JSQMessagesToolbarContentView *)loadToolbarContentView;
+- (nullable JSQMessagesToolbarContentView *)loadToolbarContentView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Views/JSQMessagesLoadEarlierHeaderView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesLoadEarlierHeaderView.h
@@ -18,6 +18,8 @@
 
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class JSQMessagesLoadEarlierHeaderView;
 
 /**
@@ -69,7 +71,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesLoadEarlierHeaderViewHeight;
  *  @return The initialized `UINib` object or `nil` if there were errors during
  *  initialization or the nib file could not be located.
  */
-+ (UINib *)nib;
++ (nullable UINib *)nib;
 
 /**
  *  Returns the default string used to identify the reusable header view.
@@ -79,3 +81,5 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesLoadEarlierHeaderViewHeight;
 + (NSString *)headerReuseIdentifier;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Views/JSQMessagesLoadEarlierHeaderView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesLoadEarlierHeaderView.h
@@ -59,7 +59,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesLoadEarlierHeaderViewHeight;
 /**
  *  Returns the load button of the header view.
  */
-@property (weak, nonatomic, readonly) UIButton *loadButton;
+@property (nonatomic, readonly) UIButton *loadButton;
 
 #pragma mark - Class methods
 

--- a/JSQMessagesViewController/Views/JSQMessagesLoadEarlierHeaderView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesLoadEarlierHeaderView.m
@@ -27,7 +27,7 @@ const CGFloat kJSQMessagesLoadEarlierHeaderViewHeight = 32.0f;
 
 @interface JSQMessagesLoadEarlierHeaderView ()
 
-@property (weak, nonatomic) IBOutlet UIButton *loadButton;
+@property (nonatomic) IBOutlet UIButton *loadButton;
 
 - (IBAction)loadButtonPressed:(UIButton *)sender;
 

--- a/JSQMessagesViewController/Views/JSQMessagesMediaPlaceholderView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesMediaPlaceholderView.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  A `JSQMessagesMediaPlaceholderView` object represents a loading or placeholder
  *  view for media message objects whose media attachments are not yet available. 
@@ -34,12 +36,12 @@
 /**
  *  Returns the activity indicator view for this placeholder view, or `nil` if it does not exist.
  */
-@property (nonatomic, readonly) UIActivityIndicatorView *activityIndicatorView;
+@property (nullable, nonatomic, readonly) UIActivityIndicatorView *activityIndicatorView;
 
 /**
  *  Returns the image view for this placeholder view, or `nil` if it does not exist.
  */
-@property (nonatomic, readonly) UIImageView *imageView;
+@property (nullable, nonatomic, readonly) UIImageView *imageView;
 
 /**
  *  Creates a media placeholder view object with a light gray background and
@@ -48,7 +50,7 @@
  *  @discussion When initializing a `JSQMessagesMediaPlaceholderView` with this method,
  *  its imageView property will be nil.
  *
- *  @return An initialized `JSQMessagesMediaPlaceholderView` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesMediaPlaceholderView` object.
  */
 + (instancetype)viewWithActivityIndicator;
 
@@ -59,7 +61,7 @@
  *  @discussion When initializing a `JSQMessagesMediaPlaceholderView` with this method,
  *  its activityIndicatorView property will be nil.
  *
- *  @return An initialized `JSQMessagesMediaPlaceholderView` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesMediaPlaceholderView` object.
  */
 + (instancetype)viewWithAttachmentIcon;
 
@@ -70,7 +72,7 @@
  *  @param backgroundColor       The background color of the view. This value must not be `nil`.
  *  @param activityIndicatorView An initialized activity indicator to be added and centered in the view. This value must not be `nil`.
  *
- *  @return An initialized `JSQMessagesMediaPlaceholderView` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesMediaPlaceholderView` object.
  */
 - (instancetype)initWithFrame:(CGRect)frame
               backgroundColor:(UIColor *)backgroundColor
@@ -83,10 +85,12 @@
  *  @param backgroundColor The background color of the view. This value must not be `nil`.
  *  @param imageView       An initialized image view to be added and centered in the view. This value must not be `nil`.
  *
- *  @return An initialized `JSQMessagesMediaPlaceholderView` object if successful, `nil` otherwise.
+ *  @return An initialized `JSQMessagesMediaPlaceholderView` object.
  */
 - (instancetype)initWithFrame:(CGRect)frame
               backgroundColor:(UIColor *)backgroundColor
                     imageView:(UIImageView *)imageView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Views/JSQMessagesMediaPlaceholderView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesMediaPlaceholderView.h
@@ -34,12 +34,12 @@
 /**
  *  Returns the activity indicator view for this placeholder view, or `nil` if it does not exist.
  */
-@property (nonatomic, weak, readonly) UIActivityIndicatorView *activityIndicatorView;
+@property (nonatomic, readonly) UIActivityIndicatorView *activityIndicatorView;
 
 /**
  *  Returns the image view for this placeholder view, or `nil` if it does not exist.
  */
-@property (nonatomic, weak, readonly) UIImageView *imageView;
+@property (nonatomic, readonly) UIImageView *imageView;
 
 /**
  *  Creates a media placeholder view object with a light gray background and

--- a/JSQMessagesViewController/Views/JSQMessagesToolbarContentView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesToolbarContentView.h
@@ -37,7 +37,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesToolbarContentViewHorizontalSpacingD
 /**
  *  Returns the text view in which the user composes a message.
  */
-@property (weak, nonatomic, readonly) JSQMessagesComposerTextView *textView;
+@property (nonatomic, readonly) JSQMessagesComposerTextView *textView;
 
 /**
  *  A custom button item displayed on the left of the toolbar content view.
@@ -49,7 +49,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesToolbarContentViewHorizontalSpacingD
  *  If the frame of this button is equal to `CGRectZero` when set, then a default frame size will be used.
  *  Set this value to `nil` to remove the button.
  */
-@property (weak, nonatomic) UIButton *leftBarButtonItem;
+@property (nonatomic) UIButton *leftBarButtonItem;
 
 /**
  *  Specifies the width of the leftBarButtonItem.
@@ -73,7 +73,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesToolbarContentViewHorizontalSpacingD
  *  However, you will be completely responsible for responding to all touch events for these buttons
  *  in your `JSQMessagesViewController` subclass.
  */
-@property (weak, nonatomic, readonly) UIView *leftBarButtonContainerView;
+@property (nonatomic, readonly) UIView *leftBarButtonContainerView;
 
 /**
  *  A custom button item displayed on the right of the toolbar content view.
@@ -85,7 +85,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesToolbarContentViewHorizontalSpacingD
  *  If the frame of this button is equal to `CGRectZero` when set, then a default frame size will be used.
  *  Set this value to `nil` to remove the button.
  */
-@property (weak, nonatomic) UIButton *rightBarButtonItem;
+@property (nonatomic) UIButton *rightBarButtonItem;
 
 /**
  *  Specifies the width of the rightBarButtonItem.
@@ -109,7 +109,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesToolbarContentViewHorizontalSpacingD
  *  However, you will be completely responsible for responding to all touch events for these buttons
  *  in your `JSQMessagesViewController` subclass.
  */
-@property (weak, nonatomic, readonly) UIView *rightBarButtonContainerView;
+@property (nonatomic, readonly) UIView *rightBarButtonContainerView;
 
 #pragma mark - Class methods
 

--- a/JSQMessagesViewController/Views/JSQMessagesToolbarContentView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesToolbarContentView.m
@@ -25,16 +25,16 @@ const CGFloat kJSQMessagesToolbarContentViewHorizontalSpacingDefault = 8.0f;
 
 @interface JSQMessagesToolbarContentView ()
 
-@property (weak, nonatomic) IBOutlet JSQMessagesComposerTextView *textView;
+@property (nonatomic) IBOutlet JSQMessagesComposerTextView *textView;
 
-@property (weak, nonatomic) IBOutlet UIView *leftBarButtonContainerView;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *leftBarButtonContainerViewWidthConstraint;
+@property (nonatomic) IBOutlet UIView *leftBarButtonContainerView;
+@property (nonatomic) IBOutlet NSLayoutConstraint *leftBarButtonContainerViewWidthConstraint;
 
-@property (weak, nonatomic) IBOutlet UIView *rightBarButtonContainerView;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *rightBarButtonContainerViewWidthConstraint;
+@property (nonatomic) IBOutlet UIView *rightBarButtonContainerView;
+@property (nonatomic) IBOutlet NSLayoutConstraint *rightBarButtonContainerViewWidthConstraint;
 
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *leftHorizontalSpacingConstraint;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *rightHorizontalSpacingConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *leftHorizontalSpacingConstraint;
+@property (nonatomic) IBOutlet NSLayoutConstraint *rightHorizontalSpacingConstraint;
 
 @end
 

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.h
@@ -19,6 +19,8 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /**
  *  A constant defining the default height of a `JSQMessagesTypingIndicatorFooterView`.
  */
@@ -39,7 +41,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight;
  *  @return The initialized `UINib` object or `nil` if there were errors during
  *  initialization or the nib file could not be located.
  */
-+ (UINib *)nib;
++ (nullable UINib *)nib;
 
 /**
  *  Returns the default string used to identify the reusable footer view.
@@ -65,3 +67,5 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight;
                  forCollectionView:(UICollectionView *)collectionView;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.m
@@ -27,11 +27,11 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
 
 @interface JSQMessagesTypingIndicatorFooterView ()
 
-@property (weak, nonatomic) IBOutlet UIImageView *bubbleImageView;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *bubbleImageViewRightHorizontalConstraint;
+@property (nonatomic) IBOutlet UIImageView *bubbleImageView;
+@property (nonatomic) IBOutlet NSLayoutConstraint *bubbleImageViewRightHorizontalConstraint;
 
-@property (weak, nonatomic) IBOutlet UIImageView *typingIndicatorImageView;
-@property (weak, nonatomic) IBOutlet NSLayoutConstraint *typingIndicatorImageViewRightHorizontalConstraint;
+@property (nonatomic) IBOutlet UIImageView *typingIndicatorImageView;
+@property (nonatomic) IBOutlet NSLayoutConstraint *typingIndicatorImageViewRightHorizontalConstraint;
 
 @end
 


### PR DESCRIPTION
Fixes #776 to facilitate Swift development.

* Adds `nullable` and `nonnullable`
* Use `strong` instead of `weak` for `IBOutlets` as per ["new" convention](http://stackoverflow.com/a/31395938/254422)
* Guarantee instantiated objects now that we can specify `nonnull` parameters

There are some tests that now generates warnings (for nullable parameters). We could probably remove these tests since the compiler will now generate warnings when passing nullable arguments. Let me know and I'll update this PR.