### PR TITLE
Implemented adaptive UIViewController responses to invalidate message bubble cache on size change.

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -310,6 +310,22 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     }
 }
 
+- (void)resetLayoutAndCaches {
+    JSQMessagesCollectionViewFlowLayoutInvalidationContext *context = [JSQMessagesCollectionViewFlowLayoutInvalidationContext context];
+    context.invalidateFlowLayoutMessagesCache = YES;
+    [self.collectionView.collectionViewLayout invalidateLayoutWithContext:context];
+}
+
+-(void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
+    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
+    [self resetLayoutAndCaches];
+}
+
+- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
+    [super traitCollectionDidChange:previousTraitCollection];
+    [self resetLayoutAndCaches];
+}
+
 #pragma mark - Messages view controller
 
 - (void)didPressSendButton:(UIButton *)button


### PR DESCRIPTION
:muscle::sunglasses::facepunch:

Specifically, I implemented `viewWillTransitionToSize:withTransitionCoordinator:` and `traitCollectionDidChange:` for JSQMessagesViewController to remove cached message bubble sizes on size class transition. This is necessary to support split-screen multitasking.

This should fix #1212.

## Before:
![img_0010](https://cloud.githubusercontent.com/assets/853032/10255868/31f8989a-691b-11e5-89a1-a65df475283e.PNG)

## After:
![img_0011 2](https://cloud.githubusercontent.com/assets/853032/10255864/2cabea36-691b-11e5-961a-6e2045cce9f8.PNG)
