### PR TITLE
[Localization] Update French version of Send button to match iOS version

### DIFF
--- a/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/fr.lproj/JSQMessages.strings
+++ b/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/fr.lproj/JSQMessages.strings
@@ -24,6 +24,6 @@
 
 "load_earlier_messages" = "Messages précedents";
 
-"send" = "Envoi";
+"send" = "Envoyer";
 
 "new_message" = "Nouveau message";


### PR DESCRIPTION
"Envoi" becomes "Envoyer". Makes more sense in French