### PR TITLE
fix keyboard hiding bug on iOS 9

### DIFF
--- a/JSQMessagesViewController/Categories/UIDevice+JSQMessages.h
+++ b/JSQMessagesViewController/Categories/UIDevice+JSQMessages.h
@@ -25,4 +25,9 @@
  */
 + (BOOL)jsq_isCurrentDeviceBeforeiOS8;
 
+/**
+ *  @return Whether or not the current device is running a version of iOS after 9.0.
+ */
++ (BOOL)jsq_isCurrentDeviceAfteriOS9;
+
 @end

--- a/JSQMessagesViewController/Categories/UIDevice+JSQMessages.m
+++ b/JSQMessagesViewController/Categories/UIDevice+JSQMessages.m
@@ -26,4 +26,10 @@
     return [[UIDevice currentDevice].systemVersion compare:@"8.0" options:NSNumericSearch] == NSOrderedAscending;
 }
 
++ (BOOL)jsq_isCurrentDeviceAfteriOS9
+{
+    // iOS > 9.0
+    return [[UIDevice currentDevice].systemVersion compare:@"9.0" options:NSNumericSearch] == NSOrderedDescending;
+}
+
 @end

--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -187,7 +187,24 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
 
 - (void)jsq_didReceiveKeyboardDidShowNotification:(NSNotification *)notification
 {
-    self.keyboardView = self.textView.inputAccessoryView.superview;
+    UIView *keyboardViewProxy = nil;
+    if ([UIDevice jsq_isCurrentDeviceAfteriOS9]) {
+        NSPredicate *windowPredicate = [NSPredicate predicateWithFormat:@"self isMemberOfClass: %@", NSClassFromString(@"UIRemoteKeyboardWindow")];
+        UIWindow *keyboardWindow = [[[UIApplication sharedApplication].windows filteredArrayUsingPredicate:windowPredicate] firstObject];
+        
+        for (UIView *subview in keyboardWindow.subviews) {
+            for (UIView *hostview in subview.subviews) {
+                if ([hostview isMemberOfClass:NSClassFromString(@"UIInputSetHostView")]) {
+                    keyboardViewProxy = hostview;
+                    break;
+                }
+            }
+        }
+    } else {
+        keyboardViewProxy = self.textView.inputAccessoryView.superview;
+    }
+
+    self.keyboardView = keyboardViewProxy;
     [self jsq_setKeyboardViewHidden:NO];
 
     [self jsq_handleKeyboardNotification:notification completion:^(BOOL finished) {


### PR DESCRIPTION
When device iOS version >= 9.0, if you try to hide keyboard using pan gesture, it performs wired, because it can not find the right keyboard using pervious method.

origin solution from: https://github.com/slackhq/SlackTextViewController/blob/master/Source%2FSLKInputAccessoryView.m