### PR TITLE
add completion block parameters for playAlertSoundWithFilename method…

### DIFF
--- a/JSQMessagesViewController/Categories/JSQSystemSoundPlayer+JSQMessages.m
+++ b/JSQMessagesViewController/Categories/JSQSystemSoundPlayer+JSQMessages.m
@@ -62,10 +62,14 @@ static NSString * const kJSQMessageSentSoundName = @"message_sent";
     NSString *fileName = [NSString stringWithFormat:@"JSQMessagesAssets.bundle/Sounds/%@", soundName];
     
     if (asAlert) {
-        [[JSQSystemSoundPlayer sharedPlayer] playAlertSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF];
+        [[JSQSystemSoundPlayer sharedPlayer] playAlertSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF completion:^{
+            
+        }];
     }
     else {
-        [[JSQSystemSoundPlayer sharedPlayer] playSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF];
+        [[JSQSystemSoundPlayer sharedPlayer] playSoundWithFilename:fileName fileExtension:kJSQSystemSoundTypeAIFF completion:^{
+            
+        }];
     }
     
     //  restore original bundle


### PR DESCRIPTION
Latest JSQSystemSoundPlayer library add a completion block parameter in both playAlertSoundWithFilename method and playSoundWithFilename method. 

It will cause an compilation error if using JSQMessageViewController without cocoapod.

