### PR TITLE
Fix typo in appledoc tag name

### DIFF
--- a/JSQMessagesViewController/Categories/UIImage+JSQMessages.h
+++ b/JSQMessagesViewController/Categories/UIImage+JSQMessages.h
@@ -52,7 +52,7 @@
 /**
  *  @return The compact message bubble image. 
  *
- *  @disscussion This is the default bubble image used by `JSQMessagesBubbleImageFactory`.
+ *  @discussion This is the default bubble image used by `JSQMessagesBubbleImageFactory`.
  */
 + (UIImage *)jsq_bubbleCompactImage;
 


### PR DESCRIPTION
Prevents from "Unknown command tag name 'disscussion'; did you mean 'discussion'?" warning