### PR TITLE
marked designated initializers (issue #1142)

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.h
@@ -110,6 +110,12 @@ FOUNDATION_EXPORT NSString * const JSQMessagesKeyboardControllerUserInfoKeyKeybo
  */
 @property (assign, nonatomic, readonly) CGRect currentKeyboardFrame;
 
+
+/**
+ *  Not a valid initializer. Use initWithTextView:contextView:panGestureRecognizer:delegate to init a new keyboard controller.
+ */
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
  *  Creates a new keyboard controller object with the specified textView, contextView, panGestureRecognizer, and delegate.
  *
@@ -123,7 +129,7 @@ FOUNDATION_EXPORT NSString * const JSQMessagesKeyboardControllerUserInfoKeyKeybo
 - (instancetype)initWithTextView:(UITextView *)textView
                      contextView:(UIView *)contextView
             panGestureRecognizer:(UIPanGestureRecognizer *)panGestureRecognizer
-                        delegate:(id<JSQMessagesKeyboardControllerDelegate>)delegate;
+                        delegate:(id<JSQMessagesKeyboardControllerDelegate>)delegate NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Tells the keyboard controller that it should begin listening for system keyboard notifications.

--- a/JSQMessagesViewController/Factories/JSQMessagesMediaViewBubbleImageMasker.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesMediaViewBubbleImageMasker.h
@@ -61,7 +61,7 @@
  *  @see JSQMessagesBubbleImageFactory.
  *  @see JSQMessagesBubbleImage.
  */
-- (instancetype)initWithBubbleImageFactory:(JSQMessagesBubbleImageFactory *)bubbleImageFactory;
+- (instancetype)initWithBubbleImageFactory:(JSQMessagesBubbleImageFactory *)bubbleImageFactory NS_DESIGNATED_INITIALIZER;
 
 /**
  *  Applies an outgoing bubble image mask to the specified mediaView.

--- a/JSQMessagesViewController/Model/JSQMessage.h
+++ b/JSQMessagesViewController/Model/JSQMessage.h
@@ -132,7 +132,7 @@
                            media:(id<JSQMessageMediaData>)media;
 
 /**
- Not a valid initializer.
+ *  Not a valid initializer.
  */
 - (id)init NS_UNAVAILABLE;
 

--- a/JSQMessagesViewController/Model/JSQMessagesAvatarImage.h
+++ b/JSQMessagesViewController/Model/JSQMessagesAvatarImage.h
@@ -76,10 +76,10 @@
  */
 - (instancetype)initWithAvatarImage:(UIImage *)avatarImage
                    highlightedImage:(UIImage *)highlightedImage
-                   placeholderImage:(UIImage *)placeholderImage;
+                   placeholderImage:(UIImage *)placeholderImage NS_DESIGNATED_INITIALIZER;
 
 /**
- Not a valid initializer.
+ *  Not a valid initializer.
  */
 - (id)init NS_UNAVAILABLE;
 

--- a/JSQMessagesViewController/Model/JSQMessagesBubbleImage.h
+++ b/JSQMessagesViewController/Model/JSQMessagesBubbleImage.h
@@ -50,10 +50,10 @@
  *
  *  @see JSQMessagesBubbleImageFactory.
  */
-- (instancetype)initWithMessageBubbleImage:(UIImage *)image highlightedImage:(UIImage *)highlightedImage;
+- (instancetype)initWithMessageBubbleImage:(UIImage *)image highlightedImage:(UIImage *)highlightedImage NS_DESIGNATED_INITIALIZER;
 
 /**
- Not a valid initializer.
+ *  Not a valid initializer.
  */
 - (id)init NS_UNAVAILABLE;
 


### PR DESCRIPTION
## Pull request checklist

- [x] This fixes issue #1142.
- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have squashed my commits into 1 commit.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: :muscle::sunglasses::facepunch:

## What's in this pull request?

I marked the designated initializers in the following classes:
* `JSQMessagesKeyboardController`
* `JSQMessagesMediaViewBubbleImageMasker`
* `JSQMessagesAvatarImage`
* `JSQMessagesBubbleImageFactory`

I didn't add `NS_DESIGNATED_INITIALIZER` to the `JSQMediaItem` class and its subclasses (as discussed in issue #1142). I also didn't define the designated initializers for `JSQMessagesMediaPlaceholderview` and `JSQMessage`. These classes have designated initializers, but they aren't defined in the interface. 
All other classes don't define custom `init`-methods.

I also defined `init` on `JSQMessagesKeyboardController` with `NS_UNAVAILABLE` since there is no implementation and it can't be configured after init (properties are readonly).


