### PR TITLE
Bug Fix #1449

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -194,6 +194,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     NSParameterAssert(self.senderDisplayName != nil);
 
     [super viewWillAppear:animated];
+    self.toolbarHeightConstraint.constant = self.inputToolbar.preferredDefaultHeight;
     [self.view layoutIfNeeded];
     [self.collectionView.collectionViewLayout invalidateLayout];
 


### PR DESCRIPTION
## Pull request checklist

- [Yes] This fixes issue #1449
- [Yes] All tests pass. Demo project builds and runs.
- [ No merge conflicts] I have resolved any merge conflicts.
- [YES] I have squashed my commits into 1 commit.
- [Yes] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____

## What's in this pull request?

>...

It doesn't seem like you can change the height of the inputToolbar using the documented property preferredDefaultHeight since it is used to configure the height constraint in viewDidLoad.
In order to fix the bug I added the line of code:

self.toolbarHeightConstraint.constant = self.inputToolbar.preferredDefaultHeight;

In the method:

viewWillAppear, and now the view load with the correct constraints.