### PR TITLE
Adding a configurable property to JSQMessagesViewController controlli…

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,10 +1,8 @@
 ## New issue checklist
 <!-- Before submitting this issue, make sure you have done the following -->
 
-- [ ] I have read all of the [`README`](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/README.md).
-- [ ] I have read the [documentation](http://cocoadocs.org/docsets/JSQMessagesViewController/).
+- [ ] I have read all of the [`README`](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/README.md), [documentation](http://cocoadocs.org/docsets/JSQMessagesViewController/), and [FAQ](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/Documentation/faq.md).
 - [ ] I have reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____
-- [ ] I have reviewed the [FAQ](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/Documentation/faq.md).
 - [ ] I have searched [existing issues](https://github.com/jessesquires/JSQMessagesViewController/issues?q=is%3Aissue+sort%3Acreated-desc) and **this is not a duplicate**.
 
 ### General information
@@ -12,8 +10,7 @@
 - Library version(s):
 - iOS version(s):
 - Devices/Simulators affected:
-- Reproducible in the demo project (Y/N): 
-- Link to a project that exhibits the issue (if possible):
+- Reproducible in the demo project? (Y/N): 
 - List any related issues:
 
 ## Bug report
@@ -31,15 +28,9 @@
 
 > ...
 
-#### Crash log?
-<!-- Can you provide a crash log? -->
+#### Crash log? Screenshots? Videos? Sample project?
 
 >...
-
-#### Screenshots or videos?
-<!-- Can you provide screenshots, GIFs, or videos showing the issue? -->
-
-> ...
 
 ## Question
 <!-- If this is a question, please provide the following information. Otherwise, you can delete this section. -->
@@ -48,9 +39,5 @@
 
 ## Feature Request
 <!-- If this is a feature request, please provide the following information. Otherwise, you can delete this section. -->
-
-- Why should it be included in the library?
-- What problems does it solve?
-- Please provide design/implementation details, if possible.
 
 > ...

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,11 +10,10 @@
 - Library version(s):
 - iOS version(s):
 - Devices/Simulators affected:
-- Reproducible in the demo project? (Y/N): 
-- List any related issues:
+- Reproducible in the demo project? (Yes/No): 
+- Related issues:
 
 ## Bug report
-<!-- If this is a bug report, please provide the following information. Otherwise, you can delete this section. -->
 
 #### Expected behavior
 
@@ -32,12 +31,6 @@
 
 >...
 
-## Question
-<!-- If this is a question, please provide the following information. Otherwise, you can delete this section. -->
-
->...
-
-## Feature Request
-<!-- If this is a feature request, please provide the following information. Otherwise, you can delete this section. -->
+## Question or Feature Request
 
 > ...

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -41,8 +41,6 @@
 
 > ...
 
-</details>
-
 ## Question
 <!-- If this is a question, please provide the following information. Otherwise, you can delete this section. -->
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,6 @@
 
 - [ ] All tests pass. Demo project builds and runs.
 - [ ] I have resolved any merge conflicts.
-- [ ] I have squashed my commits into 1 commit.
 - [ ] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____
 
 #### This fixes issue #___.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,11 @@
 ## Pull request checklist
 
-- [ ] This fixes issue #<issue number>.
 - [ ] All tests pass. Demo project builds and runs.
 - [ ] I have resolved any merge conflicts.
 - [ ] I have squashed my commits into 1 commit.
 - [ ] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____
+
+#### This fixes issue #___.
 
 ## What's in this pull request?
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
    - LANG=en_US.UTF-8
    - WORKSPACE="JSQMessages.xcworkspace"
    - IOS_SCHEME="JSQMessages"
-   - IOS_SDK=iphonesimulator9.1
+   - IOS_SDK=iphonesimulator9.3
 
    matrix:
    - DESTINATION="OS=8.1,name=iPhone 5"      SDK="$IOS_SDK" SCHEME="$IOS_SCHEME"  RUN_TESTS="YES"  BUILD_EXAMPLE="NO"  POD_LINT="NO"   COVERAGE="NO"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7.1
+osx_image: xcode7.3
 
 env:
    global:
@@ -14,6 +14,10 @@ env:
 
 before_install:
 - gem install xcpretty --no-rdoc --no-ri --no-document --quiet
+
+# skip pod install on travis-ci
+# since we check-in the pods folder, etc. this isn't needed
+install: true
 
 script:
 

--- a/Documentation/contributor_onboarding.md
+++ b/Documentation/contributor_onboarding.md
@@ -58,6 +58,7 @@ Core contributors have push access and are responsible for:
 
 Current core contributors:
 - Harlan Haskans ([**@harlanhaskins**](https://github.com/harlanhaskins))
+- Eli Burke ([**@eliburke**](https://github.com/eliburke))
 
 ## Pushing code
 

--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -104,6 +104,10 @@
 		88C00A501A44D4D800B004B3 /* JSQPhotoMediaItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C00A4F1A44D4D800B004B3 /* JSQPhotoMediaItemTests.m */; };
 		88C00A521A44D4E500B004B3 /* JSQVideoMediaItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C00A511A44D4E500B004B3 /* JSQVideoMediaItemTests.m */; };
 		88C4583019F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C4582F19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m */; };
+		8990D5961CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 8990D5951CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.m */; };
+		8990D5971CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.m in Sources */ = {isa = PBXBuildFile; fileRef = 8990D5951CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.m */; };
+		8990D59A1CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8990D5991CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.m */; };
+		8990D59B1CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8990D5991CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.m */; };
 		BF6DA766BD3B8893A67FB2BD /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3F882AA48978C11F64DC2DF /* libPods.a */; };
 		C8994EF7DDBE74B9E3F1A16C /* libPods-JSQMessagesTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E23238C8D8DF79244DEE1787 /* libPods-JSQMessagesTests.a */; };
 		E8877F1947CE8050ECCD9539 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3F882AA48978C11F64DC2DF /* libPods.a */; };
@@ -268,6 +272,10 @@
 		88C00A511A44D4E500B004B3 /* JSQVideoMediaItemTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQVideoMediaItemTests.m; sourceTree = "<group>"; };
 		88C4582E19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesMediaViewBubbleImageMasker.h; sourceTree = "<group>"; };
 		88C4582F19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaViewBubbleImageMasker.m; sourceTree = "<group>"; };
+		8990D5941CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesTypingIndicatorAnimator.h; sourceTree = "<group>"; };
+		8990D5951CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesTypingIndicatorAnimator.m; sourceTree = "<group>"; };
+		8990D5981CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesTypingIndicatorCircleView.h; sourceTree = "<group>"; };
+		8990D5991CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesTypingIndicatorCircleView.m; sourceTree = "<group>"; };
 		AD6E75315517DE46FE495B65 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		C3F882AA48978C11F64DC2DF /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E23238C8D8DF79244DEE1787 /* libPods-JSQMessagesTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JSQMessagesTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -549,6 +557,10 @@
 				88A25FA019D8E01A00924534 /* JSQMessagesTypingIndicatorFooterView.h */,
 				88A25FA119D8E01A00924534 /* JSQMessagesTypingIndicatorFooterView.m */,
 				88A25FA219D8E01A00924534 /* JSQMessagesTypingIndicatorFooterView.xib */,
+				8990D5941CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.h */,
+				8990D5951CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.m */,
+				8990D5981CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.h */,
+				8990D5991CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.m */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -852,6 +864,7 @@
 				8885734D19DE55D000E89D20 /* NSUserDefaults+DemoSettings.m in Sources */,
 				883C11781A09FB100092A16D /* JSQMessagesCellTextView.m in Sources */,
 				88A25FB919D8E01A00924534 /* UIView+JSQMessages.m in Sources */,
+				8990D59A1CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.m in Sources */,
 				88A25FCA19D8E01A00924534 /* JSQMessagesCollectionView.m in Sources */,
 				88A25FD219D8E01A00924534 /* JSQMessagesLabel.m in Sources */,
 				88445B4019E1B4470014F889 /* JSQLocationMediaItem.m in Sources */,
@@ -869,6 +882,7 @@
 				88A25FBF19D8E01A00924534 /* JSQMessagesTimestampFormatter.m in Sources */,
 				88A25FE019D8E0C400924534 /* DemoModelData.m in Sources */,
 				88A25F3C19D8DF2500924534 /* main.m in Sources */,
+				8990D5961CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.m in Sources */,
 				88A25F3719D8DF2500924534 /* AppDelegate.m in Sources */,
 				886FFD2E19E9A65D00EB8485 /* UIDevice+JSQMessages.m in Sources */,
 				88B5C41F1B7C422900EC79D4 /* JSQMessagesBubblesSizeCalculator.m in Sources */,
@@ -905,9 +919,11 @@
 				88A2600B19D8E18400924534 /* JSQMessagesCollectionViewFlowLayoutTests.m in Sources */,
 				88A2601019D8E18400924534 /* JSQMessageTextTests.m in Sources */,
 				88A2600D19D8E18400924534 /* JSQMessageMediaTests.m in Sources */,
+				8990D5971CB34629003D0E69 /* JSQMessagesTypingIndicatorAnimator.m in Sources */,
 				88A2600719D8E18400924534 /* JSQMessagesAvatarImageFactoryTests.m in Sources */,
 				88A2600419D8E18400924534 /* JSQMessagesUIViewTests.m in Sources */,
 				88A2600F19D8E18400924534 /* JSQMessagesBubbleImageTests.m in Sources */,
+				8990D59B1CB34725003D0E69 /* JSQMessagesTypingIndicatorCircleView.m in Sources */,
 				88A2600E19D8E18400924534 /* JSQMessagesAvatarImageTests.m in Sources */,
 				88A2600919D8E18400924534 /* JSQMessagesTimestampFormatterTests.m in Sources */,
 				88A2601419D8E18400924534 /* JSQMessagesComposerTextViewTests.m in Sources */,

--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F0EFE0F1AC23D7E003FF3DB /* MobileCoreServices.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F0EFE0E1AC23D7E003FF3DB /* MobileCoreServices.framework */; };
 		88078A9D19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 88078A9C19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m */; };
 		88324C3419F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88324C3319F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m */; };
 		883C11781A09FB100092A16D /* JSQMessagesCellTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 883C11771A09FB100092A16D /* JSQMessagesCellTextView.m */; };
@@ -124,9 +125,9 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		0B4D05069814EB50FB0F4229 /* Pods-JSQMessagesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.release.xcconfig"; sourceTree = "<group>"; };
-		1D4D3B82D90888BCEAF890D3 /* Pods-JSQMessagesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.debug.xcconfig"; sourceTree = "<group>"; };
-		3BA6237809BE0D008CFE3697 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		1F0EFE0E1AC23D7E003FF3DB /* MobileCoreServices.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MobileCoreServices.framework; path = System/Library/Frameworks/MobileCoreServices.framework; sourceTree = SDKROOT; };
+		242A2BCAF25E39CC1DAF654E /* Pods-JSQMessagesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.release.xcconfig"; sourceTree = "<group>"; };
+		4D257782A244F7688A2F6AA8 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
 		88078A9B19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesMediaPlaceholderView.h; sourceTree = "<group>"; };
 		88078A9C19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaPlaceholderView.m; sourceTree = "<group>"; };
 		88324C3319F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaViewBubbleImageMaskerTests.m; sourceTree = "<group>"; };
@@ -279,6 +280,7 @@
 		AD6E75315517DE46FE495B65 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
 		C3F882AA48978C11F64DC2DF /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E23238C8D8DF79244DEE1787 /* libPods-JSQMessagesTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JSQMessagesTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F68D899A0AE7E8180C89579D /* Pods-JSQMessagesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -286,6 +288,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F0EFE0F1AC23D7E003FF3DB /* MobileCoreServices.framework in Frameworks */,
 				88445B4419E1B5110014F889 /* MapKit.framework in Frameworks */,
 				88445B4219E1B50B0014F889 /* CoreLocation.framework in Frameworks */,
 				88445B3719E0AE5C0014F889 /* QuartzCore.framework in Frameworks */,
@@ -318,6 +321,7 @@
 		636A8663AEEE5C37B65C515D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				1F0EFE0E1AC23D7E003FF3DB /* MobileCoreServices.framework */,
 				88445B3419E0AE4A0014F889 /* CoreGraphics.framework */,
 				88445B4119E1B50B0014F889 /* CoreLocation.framework */,
 				88445B3219E0AE450014F889 /* Foundation.framework */,
@@ -334,10 +338,10 @@
 		842892590A65F355D8619D29 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				3BA6237809BE0D008CFE3697 /* Pods.debug.xcconfig */,
 				AD6E75315517DE46FE495B65 /* Pods.release.xcconfig */,
-				1D4D3B82D90888BCEAF890D3 /* Pods-JSQMessagesTests.debug.xcconfig */,
-				0B4D05069814EB50FB0F4229 /* Pods-JSQMessagesTests.release.xcconfig */,
+				4D257782A244F7688A2F6AA8 /* Pods.debug.xcconfig */,
+				F68D899A0AE7E8180C89579D /* Pods-JSQMessagesTests.debug.xcconfig */,
+				242A2BCAF25E39CC1DAF654E /* Pods-JSQMessagesTests.release.xcconfig */,
 			);
 			name = Pods;
 			sourceTree = "<group>";
@@ -1046,7 +1050,7 @@
 		};
 		88A25F2619D8DEC500924534 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 3BA6237809BE0D008CFE3697 /* Pods.debug.xcconfig */;
+			baseConfigurationReference = 4D257782A244F7688A2F6AA8 /* Pods.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
@@ -1084,7 +1088,7 @@
 		};
 		88A25F2919D8DEC500924534 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 1D4D3B82D90888BCEAF890D3 /* Pods-JSQMessagesTests.debug.xcconfig */;
+			baseConfigurationReference = F68D899A0AE7E8180C89579D /* Pods-JSQMessagesTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;
@@ -1103,7 +1107,7 @@
 		};
 		88A25F2A19D8DEC500924534 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0B4D05069814EB50FB0F4229 /* Pods-JSQMessagesTests.release.xcconfig */;
+			baseConfigurationReference = 242A2BCAF25E39CC1DAF654E /* Pods-JSQMessagesTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES = YES;

--- a/JSQMessages.xcodeproj/xcshareddata/xcschemes/JSQMessages.xcscheme
+++ b/JSQMessages.xcodeproj/xcshareddata/xcschemes/JSQMessages.xcscheme
@@ -11,8 +11,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "D14DE867BBE115B80620BD22C0E35F79"
@@ -26,8 +25,7 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "88A25F0119D8DEC400924534"
@@ -41,8 +39,7 @@
             buildForRunning = "YES"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES"
-            hideIssues = "NO">
+            buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "88A25F1A19D8DEC400924534"

--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -93,6 +93,11 @@
      *
      *  self.inputToolbar.maximumHeight = 150;
      */
+    
+    /**
+     *  Set whether you want the typing indicator to be animated
+     */
+    self.animatedTypingIndicator = YES;
 }
 
 - (void)viewWillAppear:(BOOL)animated

--- a/JSQMessagesTests/ControllerTests/JSQMessagesViewControllerTests.m
+++ b/JSQMessagesTests/ControllerTests/JSQMessagesViewControllerTests.m
@@ -63,6 +63,7 @@
     XCTAssertEqualObjects(vc.outgoingCellIdentifier, [JSQMessagesCollectionViewCellOutgoing cellReuseIdentifier], @"Property should be equal to default value");
 
     XCTAssertEqual(vc.showTypingIndicator, NO, @"Property should be equal to default value");
+    XCTAssertEqual(vc.animatedTypingIndicator, NO, @"Property should be equal to default value");
     XCTAssertEqual(vc.showLoadEarlierMessagesHeader, NO, @"Property should be equal to default value");
 }
 

--- a/JSQMessagesTests/ModelTests/JSQLocationMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQLocationMediaItemTests.m
@@ -12,6 +12,7 @@
 
 #import "JSQLocationMediaItem.h"
 
+#import <MobileCoreServices/UTCoreTypes.h>
 
 @interface JSQLocationMediaItemTests : XCTestCase
 
@@ -59,6 +60,16 @@
     }];
     
     XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+}
+
+- (void)testCopyableItemInMediaProtocol {
+    JSQLocationMediaItem *item = [[JSQLocationMediaItem alloc] initWithLocation:self.location];
+    XCTAssertNotNil(item);
+    
+    XCTAssertEqualObjects((NSString *)kUTTypeURL, [item mediaDataType]);
+    
+    NSURL *locationURL = [[NSURL alloc] initWithString:@"http://maps.google.com/maps?z=12&t=m&q=loc:37.795313+-122.393757"];
+    XCTAssertEqualObjects(locationURL, [item mediaData]);
 }
 
 @end

--- a/JSQMessagesTests/ModelTests/JSQLocationMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQLocationMediaItemTests.m
@@ -67,8 +67,8 @@
     XCTAssertNotNil(item);
     
     XCTAssertEqualObjects((NSString *)kUTTypeURL, [item mediaDataType]);
-    
-    NSURL *locationURL = [[NSURL alloc] initWithString:@"http://maps.google.com/maps?z=12&t=m&q=loc:37.795313+-122.393757"];
+
+    NSURL *locationURL = [[NSURL alloc] initWithString:@"http://maps.apple.com/?ll=37.795313,-122.393757&z=18&q=%20"];
     XCTAssertEqualObjects(locationURL, [item mediaData]);
 }
 

--- a/JSQMessagesTests/ModelTests/JSQPhotoMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQPhotoMediaItemTests.m
@@ -12,6 +12,7 @@
 
 #import "JSQPhotoMediaItem.h"
 
+#import <MobileCoreServices/UTCoreTypes.h>
 
 @interface JSQPhotoMediaItemTests : XCTestCase
 
@@ -71,6 +72,15 @@
     item.image = [UIImage imageNamed:@"demo_avatar_jobs"];
     
     XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+}
+
+- (void)testCopyableItemInMediaProtocol {
+    JSQPhotoMediaItem *item = [[JSQPhotoMediaItem alloc] initWithImage:[UIImage imageNamed:@"demo_avatar_jobs"]];
+    XCTAssertNotNil(item);
+    XCTAssertEqual([item mediaDataType], (NSString *)kUTTypeJPEG);
+    
+    UIImage *itemImage = [[UIImage alloc] initWithData:[item mediaData]];
+    XCTAssertNotNil(itemImage);
 }
 
 @end

--- a/JSQMessagesTests/ViewTests/JSQMessagesCollectionViewTests.m
+++ b/JSQMessagesTests/ViewTests/JSQMessagesCollectionViewTests.m
@@ -41,6 +41,7 @@
     XCTAssertEqualObjects(view.backgroundColor, [UIColor whiteColor], @"Property should be equal to default value");
     XCTAssertEqual(view.keyboardDismissMode, UIScrollViewKeyboardDismissModeNone, @"Property should be equal to default value");
     XCTAssertEqual(view.alwaysBounceVertical, YES, @"Property should be equal to default value");
+    XCTAssertEqual(view.typingIndicatorAnimated, NO, @"Property should be equal to default value");
     XCTAssertEqual(view.bounces, YES, @"Property should be equal to default value");
 }
 

--- a/JSQMessagesViewController.podspec
+++ b/JSQMessagesViewController.podspec
@@ -18,8 +18,7 @@ Pod::Spec.new do |s|
 	s.source_files = 'JSQMessagesViewController/**/*.{h,m}'
 
 	s.resources = ['JSQMessagesViewController/Assets/JSQMessagesAssets.bundle', 'JSQMessagesViewController/**/*.{xib}']
-
-	s.frameworks = 'QuartzCore', 'CoreGraphics', 'CoreLocation', 'MapKit', 'UIKit', 'Foundation'
+	s.frameworks = 'QuartzCore', 'CoreGraphics', 'CoreLocation', 'MapKit', 'UIKit', 'Foundation', 'MobileCoreServices'
 	s.requires_arc = true
 
 	s.dependency 'JSQSystemSoundPlayer', '~> 2.0.1'

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -157,6 +157,17 @@
 @property (assign, nonatomic) BOOL showTypingIndicator;
 
 /**
+ *  Specifies whether the typing indicator (if shown per above property) is animated.
+ *  The animation is similar to the iMessage typing indicator animation, sequentially
+ *  darkening the dots
+ *
+ *  @discussion This property should be set correctly prior to the first visible instance
+ *  of the typing indicator as the animation loop will continue throughout the life-cycle
+ *  of the typing indicator
+ */
+@property (assign, nonatomic) BOOL animatedTypingIndicator;
+
+/**
  *  Specifies whether or not the view controller should show the "load earlier messages" header view.
  *
  *  @discussion Setting this property to `YES` will show the header view immediately.

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -112,6 +112,7 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     // [JSQMessagesCollectionViewCell registerMenuAction:@selector(delete:)];
 
     self.showTypingIndicator = NO;
+    self.animatedTypingIndicator = NO;
 
     self.showLoadEarlierMessagesHeader = NO;
 
@@ -154,6 +155,16 @@ static void * kJSQMessagesKeyValueObservingContext = &kJSQMessagesKeyValueObserv
     _showTypingIndicator = showTypingIndicator;
     [self.collectionView.collectionViewLayout invalidateLayoutWithContext:[JSQMessagesCollectionViewFlowLayoutInvalidationContext context]];
     [self.collectionView.collectionViewLayout invalidateLayout];
+}
+
+- (void) setAnimatedTypingIndicator:(BOOL)animatedTypingIndicator
+{
+    if (_animatedTypingIndicator == animatedTypingIndicator) {
+        return;
+    }
+    
+    _animatedTypingIndicator = animatedTypingIndicator;
+    [self.collectionView setTypingIndicatorAnimated:_animatedTypingIndicator];
 }
 
 - (void)setShowLoadEarlierMessagesHeader:(BOOL)showLoadEarlierMessagesHeader

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -167,7 +167,7 @@
 
 - (id)mediaData
 {
-    NSString *locationAsGoogleMapsString = [NSString stringWithFormat:@"http://maps.google.com/maps?z=12&t=m&q=loc:%f+%f", self.coordinate.latitude, self.coordinate.longitude ];
+    NSString *locationAsGoogleMapsString = [NSString stringWithFormat:@"http://maps.apple.com/?ll=%f,%f&z=18&q=%%20", self.coordinate.latitude, self.coordinate.longitude ];
     NSURL *locationURL = [[NSURL alloc] initWithString:locationAsGoogleMapsString];
     return locationURL;
 }

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -21,6 +21,8 @@
 #import "JSQMessagesMediaPlaceholderView.h"
 #import "JSQMessagesMediaViewBubbleImageMasker.h"
 
+#import <MobileCoreServices/UTCoreTypes.h>
+
 
 @interface JSQLocationMediaItem ()
 
@@ -157,6 +159,19 @@
 {
     return self.hash;
 }
+
+- (NSString *)mediaDataType
+{
+    return (NSString *)kUTTypeURL;
+}
+
+- (id)mediaData
+{
+    NSString *locationAsGoogleMapsString = [NSString stringWithFormat:@"http://maps.google.com/maps?z=12&t=m&q=loc:%f+%f", self.coordinate.latitude, self.coordinate.longitude ];
+    NSURL *locationURL = [[NSURL alloc] initWithString:locationAsGoogleMapsString];
+    return locationURL;
+}
+
 
 #pragma mark - NSObject
 

--- a/JSQMessagesViewController/Model/JSQMessageData.h
+++ b/JSQMessagesViewController/Model/JSQMessageData.h
@@ -81,8 +81,6 @@
  */
 - (NSUInteger)messageHash;
 
-@optional
-
 /**
  *  @return The body text of the message.
  *

--- a/JSQMessagesViewController/Model/JSQMessageData.h
+++ b/JSQMessagesViewController/Model/JSQMessageData.h
@@ -81,6 +81,8 @@
  */
 - (NSUInteger)messageHash;
 
+@optional
+
 /**
  *  @return The body text of the message.
  *

--- a/JSQMessagesViewController/Model/JSQMessageMediaData.h
+++ b/JSQMessagesViewController/Model/JSQMessageMediaData.h
@@ -78,4 +78,24 @@
  */
 - (NSUInteger)mediaHash;
 
+@optional
+
+/**
+ *  @return String which identifies type of the data returned by `mediaData` method.
+ *
+ *  @discussion If implemented, you must not return `nil` from this, as well as `copyableData`, method.
+ *  This type is frequently, but not necessarily, a UTI (Uniform Type Identifier). It identifies a 
+ *  representation of the data on the pasteboard. Apps can define their own types for custom data,
+ *  however, in this case, only those apps that know of the type could understand the data written to the pasteboard.
+ */
+- (NSString *)mediaDataType;
+
+/**
+ *  @return Data object of class corresponding to type returned by `mediaDataType`.
+ *
+ *  @discussion You should return an object that is of a class type appropriate to the representation type,
+ *  which typically is a UTI.
+ */
+- (id)mediaData;
+
 @end

--- a/JSQMessagesViewController/Model/JSQPhotoMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQPhotoMediaItem.m
@@ -21,6 +21,7 @@
 #import "JSQMessagesMediaPlaceholderView.h"
 #import "JSQMessagesMediaViewBubbleImageMasker.h"
 
+#import <MobileCoreServices/UTCoreTypes.h>
 
 @interface JSQPhotoMediaItem ()
 
@@ -87,6 +88,16 @@
 - (NSUInteger)mediaHash
 {
     return self.hash;
+}
+
+- (NSString *)mediaDataType
+{
+    return (NSString *)kUTTypeJPEG;
+}
+
+- (id)mediaData
+{
+    return UIImageJPEGRepresentation(self.image, 1);
 }
 
 #pragma mark - NSObject

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.h
@@ -73,6 +73,11 @@
 @property (strong, nonatomic) UIColor *typingIndicatorEllipsisColor;
 
 /**
+ *  Whether or not the typing indicator is animated.
+ */
+@property (nonatomic, assign) BOOL typingIndicatorAnimated;
+
+/**
  *  The color of the text in the load earlier messages header. The default value is a bright blue color.
  */
 @property (strong, nonatomic) UIColor *loadEarlierMessagesHeaderTextColor;

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
@@ -73,6 +73,7 @@
           withReuseIdentifier:[JSQMessagesLoadEarlierHeaderView headerReuseIdentifier]];
 
     _typingIndicatorDisplaysOnLeft = YES;
+    _typingIndicatorAnimated = NO;
     _typingIndicatorMessageBubbleColor = [UIColor jsq_messageBubbleLightGrayColor];
     _typingIndicatorEllipsisColor = [_typingIndicatorMessageBubbleColor jsq_colorByDarkeningColorWithValue:0.3f];
 
@@ -104,6 +105,7 @@
 
     [footerView configureWithEllipsisColor:self.typingIndicatorEllipsisColor
                         messageBubbleColor:self.typingIndicatorMessageBubbleColor
+                                  animated:self.typingIndicatorAnimated
                        shouldDisplayOnLeft:self.typingIndicatorDisplaysOnLeft
                          forCollectionView:self];
 

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorAnimator.h
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorAnimator.h
@@ -1,0 +1,47 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import <Foundation/Foundation.h>
+
+#import "JSQMessagesTypingIndicatorFooterView.h"
+/**
+ *  The `JSQMessagesTypingIndicatorAnimator` class manages the typing indicator animation.
+ *  This manages the animation of the three dots.
+ */
+@interface JSQMessagesTypingIndicatorAnimator : NSObject
+
+/**
+ *  Initialize the animator with the view to be animated as well as the ellipsis color
+ *  as part of the animation.  Using this default color, a second, darker color is 
+ *  calculated.
+ */
+- (instancetype) initWithTypingIndicatorView:(JSQMessagesTypingIndicatorFooterView*) view color:(UIColor*) ellipsisColor;
+
+#pragma mark - Instance Methods
+
+/**
+ *  Starts the animation
+ */
+- (void) startAnimating;
+
+/**
+ *  Ends the animation
+ */
+- (void) stopAnimating;
+
+@end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorAnimator.m
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorAnimator.m
@@ -1,0 +1,110 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import "JSQMessagesTypingIndicatorAnimator.h"
+
+#import "UIColor+JSQMessages.h"
+
+@interface JSQMessagesTypingIndicatorFooterView (Animatable)
+//
+@property (weak, nonatomic) IBOutlet UIView *typingIndicatorView1;
+@property (weak, nonatomic) IBOutlet UIView *typingIndicatorView2;
+@property (weak, nonatomic) IBOutlet UIView *typingIndicatorView3;
+
+@end
+
+
+@interface JSQMessagesTypingIndicatorAnimator()
+@property (nonatomic, strong) JSQMessagesTypingIndicatorFooterView *typingView;
+@property (nonatomic, strong) UIColor *ellipsisColor;
+@property (nonatomic, assign) BOOL animating;
+@end
+
+@implementation JSQMessagesTypingIndicatorAnimator
+
+- (instancetype) initWithTypingIndicatorView:(JSQMessagesTypingIndicatorFooterView *)view color:(UIColor*) ellipsisColor
+{
+    if (self = [self init]) {
+        _typingView = view;
+        _ellipsisColor = ellipsisColor;
+        _animating = NO;
+        
+        // Initialize Colors
+        _typingView.typingIndicatorView1.backgroundColor = ellipsisColor;
+        _typingView.typingIndicatorView2.backgroundColor = ellipsisColor;
+        _typingView.typingIndicatorView3.backgroundColor = ellipsisColor;
+    }
+    return self;
+}
+
+- (void) startAnimating
+{
+    self.animating = YES;
+    [self startTypingIndicatorAnimating:self.ellipsisColor];
+}
+
+- (void) stopAnimating
+{
+    self.animating = NO;
+}
+
+// How long does each individual dot stay dark for?
+static const CGFloat kTypingIndicatorSingleDot_Darker_AnimationDuration = 1.5f;
+// How long does it take to transition from one dark circle to another?
+static const CGFloat kTypingIndicatorSingleDot_TransitionTime = 0.4f;
+// Darkening co-efficient
+static const CGFloat kTypingIndicatorAnimatedDot_Darkening_Coefficient = 3.0f;
+
+- (void) startTypingIndicatorAnimating:(UIColor*) ellipseColor {
+    [self startTypingIndicatorAnimating:0 :@[self.typingView.typingIndicatorView1, self.typingView.typingIndicatorView2, self.typingView.typingIndicatorView3] :ellipseColor :[ellipseColor jsq_colorByDarkeningColorWithValue:kTypingIndicatorAnimatedDot_Darkening_Coefficient]];
+}
+
+- (void) startTypingIndicatorAnimating:(int) typingIndex :(NSArray*)indicatorViews :(UIColor*)ellipseColor :(UIColor*)darkerEllipseColor {
+    if (!self.animating) {
+        // Exit
+        return;
+    }
+    // Which one is dark now?
+    __block int index = typingIndex % 3;
+    int otherIndex1 = (index + 1) % 3;
+    int otherIndex2 = (index + 2) % 3;
+    
+    __block UIView *darkerView = indicatorViews[index];
+    __block UIView *lighterView1 = indicatorViews[otherIndex1];
+    __block UIView *lighterView2 = indicatorViews[otherIndex2];
+    
+    [UIView animateWithDuration:kTypingIndicatorSingleDot_TransitionTime animations:^{
+        // Darker
+        darkerView.backgroundColor = darkerEllipseColor;
+        // Lighter
+        lighterView1.backgroundColor = ellipseColor;
+        lighterView2.backgroundColor = ellipseColor;
+        
+    } completion:^(BOOL finished) {
+        // Wait
+        [UIView animateWithDuration:kTypingIndicatorSingleDot_Darker_AnimationDuration animations:^{
+            // None
+        } completion:^(BOOL finished) {
+            [self startTypingIndicatorAnimating:++index :indicatorViews :ellipseColor :darkerEllipseColor];
+        }];
+    }];
+}
+
+
+
+@end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorCircleView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorCircleView.h
@@ -1,0 +1,23 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import <UIKit/UIKit.h>
+
+@interface JSQMessagesTypingIndicatorCircleView : UIView
+
+@end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorCircleView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorCircleView.m
@@ -1,0 +1,30 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import "JSQMessagesTypingIndicatorCircleView.h"
+
+@implementation JSQMessagesTypingIndicatorCircleView
+
+- (void) setFrame:(CGRect)frame
+{
+    [super setFrame:frame];
+    // Update Radius
+    self.layer.cornerRadius = frame.size.height / 2.0f;
+}
+
+@end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.h
@@ -61,7 +61,11 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight;
  */
 - (void)configureWithEllipsisColor:(UIColor *)ellipsisColor
                 messageBubbleColor:(UIColor *)messageBubbleColor
+                          animated:(BOOL)animated
                shouldDisplayOnLeft:(BOOL)shouldDisplayOnLeft
                  forCollectionView:(UICollectionView *)collectionView;
 
+@end
+
+@interface JSQMessagesTypingIndicatorCircleView : UIView
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.h
@@ -56,6 +56,7 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight;
  *
  *  @param ellipsisColor       The color of the typing indicator ellipsis. This value must not be `nil`.
  *  @param messageBubbleColor  The color of the typing indicator message bubble. This value must not be `nil`.
+ *  @param animated            Specifies whether the typing indicator is animated
  *  @param shouldDisplayOnLeft Specifies whether the typing indicator displays on the left or right side of the collection view when displayed.
  *  @param collectionView      The collection view in which the footer view will appear. This value must not be `nil`.
  */
@@ -65,7 +66,4 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight;
                shouldDisplayOnLeft:(BOOL)shouldDisplayOnLeft
                  forCollectionView:(UICollectionView *)collectionView;
 
-@end
-
-@interface JSQMessagesTypingIndicatorCircleView : UIView
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.m
@@ -19,20 +19,15 @@
 #import "JSQMessagesTypingIndicatorFooterView.h"
 
 #import "JSQMessagesBubbleImageFactory.h"
+// Animator
+#import "JSQMessagesTypingIndicatorAnimator.h"
+#import "JSQMessagesTypingIndicatorCircleView.h"
+
 
 #import "UIImage+JSQMessages.h"
 #import "UIColor+JSQMessages.h"
 
 const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
-
-@interface JSQMessagesTypingIndicatorAnimator : NSObject
-- (id) initWithTypingIndicatorView:(JSQMessagesTypingIndicatorFooterView*) view :(UIColor*) ellipsisColor;
-@property (nonatomic, strong) JSQMessagesTypingIndicatorFooterView *typingView;
-@property (nonatomic, strong) UIColor *ellipsisColor;
-@property (nonatomic, assign) BOOL animating;
-- (void) startAnimating;
-- (void) stopAnimating;
-@end
 
 @interface JSQMessagesTypingIndicatorFooterView ()
 
@@ -40,11 +35,11 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *bubbleImageViewRightHorizontalConstraint;
 
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *typingIndicatorImageViewRightHorizontalConstraint;
-//
+// Views to be animated
 @property (weak, nonatomic) IBOutlet UIView *typingIndicatorView1;
 @property (weak, nonatomic) IBOutlet UIView *typingIndicatorView2;
 @property (weak, nonatomic) IBOutlet UIView *typingIndicatorView3;
-// Animation
+// Animator
 @property (nonatomic, strong) JSQMessagesTypingIndicatorAnimator *animator;
 
 @end
@@ -125,7 +120,7 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
     [self setNeedsUpdateConstraints];
     
     // Configure correct color and (whether/not) animated
-    [self setTypingIndicatorAnimated:animated :ellipsisColor];
+    [self setTypingIndicatorAnimated:animated ellipsisColor:ellipsisColor];
 }
 
 - (void) setTypingIndicatorEllipsisColor:(UIColor*) ellipsisColor
@@ -135,7 +130,7 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
     self.typingIndicatorView3.backgroundColor = ellipsisColor;
 }
 
-- (void) setTypingIndicatorAnimated:(BOOL) animated :(UIColor*) ellipsisColor
+- (void) setTypingIndicatorAnimated:(BOOL) animated ellipsisColor:(UIColor*) ellipsisColor
 {
     // Configure Base Color
     [self setTypingIndicatorEllipsisColor:ellipsisColor];
@@ -145,102 +140,9 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
     }
     // If animated -> New Animator
     if (animated) {
-        self.animator = [[JSQMessagesTypingIndicatorAnimator alloc] initWithTypingIndicatorView:self :ellipsisColor];
+        self.animator = [[JSQMessagesTypingIndicatorAnimator alloc] initWithTypingIndicatorView:self color:ellipsisColor];
         [self.animator startAnimating];
     }
-}
-
-@end
-
-@implementation JSQMessagesTypingIndicatorAnimator
-
-- (id) initWithTypingIndicatorView:(JSQMessagesTypingIndicatorFooterView *)view :(UIColor*) ellipsisColor
-{
-    if (self = [self init]) {
-        self.typingView = view;
-        self.ellipsisColor = ellipsisColor;
-        self.animating = NO;
-        
-        // Initialize Colors
-        self.typingView.typingIndicatorView1.backgroundColor = ellipsisColor;
-        self.typingView.typingIndicatorView2.backgroundColor = ellipsisColor;
-        self.typingView.typingIndicatorView3.backgroundColor = ellipsisColor;
-    }
-    return self;
-}
-
-- (void) startAnimating
-{
-    self.animating = YES;
-    [self startTypingIndicatorAnimating:self.ellipsisColor];
-}
-
-- (void) stopAnimating
-{
-    self.animating = NO;
-}
-
-// How long does each individual dot stay dark for?
-#define kTypingIndicatorSingleDot_Darker_AnimationDuration 1.5f
-// How long does it take to transition from one dark circle to another?
-#define kTypingIndicatorSingleDot_TransitionTime 0.4f
-// Darkening co-efficient
-#define kTypingIndicatorAnimatedDot_Darkening_Coefficient 3.0f
-
-- (void) startTypingIndicatorAnimating:(UIColor*) ellipseColor {
-    [self startTypingIndicatorAnimating:0 :@[self.typingView.typingIndicatorView1, self.typingView.typingIndicatorView2, self.typingView.typingIndicatorView3] :ellipseColor :[ellipseColor jsq_colorByDarkeningColorWithValue:kTypingIndicatorAnimatedDot_Darkening_Coefficient]];
-}
-
-- (void) startTypingIndicatorAnimating:(int) typingIndex :(NSArray*)indicatorViews :(UIColor*)ellipseColor :(UIColor*)darkerEllipseColor {
-    if (!self.animating) {
-        // Exit
-        return;
-    }
-    // Which one is dark now?
-    __block int index = typingIndex % 3;
-    int otherIndex1 = (index + 1) % 3;
-    int otherIndex2 = (index + 2) % 3;
-    
-    __block UIView *darkerView = indicatorViews[index];
-    __block UIView *lighterView1 = indicatorViews[otherIndex1];
-    __block UIView *lighterView2 = indicatorViews[otherIndex2];
-    
-    [UIView animateWithDuration:kTypingIndicatorSingleDot_TransitionTime animations:^{
-        // Darker
-        darkerView.backgroundColor = darkerEllipseColor;
-        // Lighter
-        lighterView1.backgroundColor = ellipseColor;
-        lighterView2.backgroundColor = ellipseColor;
-        
-    } completion:^(BOOL finished) {
-        // Wait
-        [UIView animateWithDuration:kTypingIndicatorSingleDot_Darker_AnimationDuration animations:^{
-            // None
-        } completion:^(BOOL finished) {
-            [self startTypingIndicatorAnimating:++index :indicatorViews :ellipseColor :darkerEllipseColor];
-        }];
-    }];
-}
-
-
-
-@end
-
-
-@implementation JSQMessagesTypingIndicatorCircleView
-
--(id) init {
-    if (self = [super init]) {
-        // Configure Circle
-    }
-    return self;
-}
-
-- (void) setFrame:(CGRect)frame
-{
-    [super setFrame:frame];
-    // Update Radius
-    self.layer.cornerRadius = frame.size.height / 2.0f;
 }
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.m
@@ -21,17 +21,31 @@
 #import "JSQMessagesBubbleImageFactory.h"
 
 #import "UIImage+JSQMessages.h"
+#import "UIColor+JSQMessages.h"
 
 const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
 
+@interface JSQMessagesTypingIndicatorAnimator : NSObject
+- (id) initWithTypingIndicatorView:(JSQMessagesTypingIndicatorFooterView*) view :(UIColor*) ellipsisColor;
+@property (nonatomic, strong) JSQMessagesTypingIndicatorFooterView *typingView;
+@property (nonatomic, strong) UIColor *ellipsisColor;
+@property (nonatomic, assign) BOOL animating;
+- (void) startAnimating;
+- (void) stopAnimating;
+@end
 
 @interface JSQMessagesTypingIndicatorFooterView ()
 
 @property (weak, nonatomic) IBOutlet UIImageView *bubbleImageView;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *bubbleImageViewRightHorizontalConstraint;
 
-@property (weak, nonatomic) IBOutlet UIImageView *typingIndicatorImageView;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *typingIndicatorImageViewRightHorizontalConstraint;
+//
+@property (weak, nonatomic) IBOutlet UIView *typingIndicatorView1;
+@property (weak, nonatomic) IBOutlet UIView *typingIndicatorView2;
+@property (weak, nonatomic) IBOutlet UIView *typingIndicatorView3;
+// Animation
+@property (nonatomic, strong) JSQMessagesTypingIndicatorAnimator *animator;
 
 @end
 
@@ -60,7 +74,6 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
     [self setTranslatesAutoresizingMaskIntoConstraints:NO];
     self.backgroundColor = [UIColor clearColor];
     self.userInteractionEnabled = NO;
-    self.typingIndicatorImageView.contentMode = UIViewContentModeScaleAspectFit;
 }
 
 #pragma mark - Reusable view
@@ -75,6 +88,7 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
 
 - (void)configureWithEllipsisColor:(UIColor *)ellipsisColor
                 messageBubbleColor:(UIColor *)messageBubbleColor
+                          animated:(BOOL)animated
                shouldDisplayOnLeft:(BOOL)shouldDisplayOnLeft
                  forCollectionView:(UICollectionView *)collectionView
 {
@@ -83,7 +97,7 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
     NSParameterAssert(collectionView != nil);
     
     CGFloat bubbleMarginMinimumSpacing = 6.0f;
-    CGFloat indicatorMarginMinimumSpacing = 26.0f;
+    CGFloat indicatorMarginMinimumSpacing = 24.0f;
     
     JSQMessagesBubbleImageFactory *bubbleImageFactory = [[JSQMessagesBubbleImageFactory alloc] init];
     
@@ -92,7 +106,8 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
         
         CGFloat collectionViewWidth = CGRectGetWidth(collectionView.frame);
         CGFloat bubbleWidth = CGRectGetWidth(self.bubbleImageView.frame);
-        CGFloat indicatorWidth = CGRectGetWidth(self.typingIndicatorImageView.frame);
+        // Constraint relies on just the first of the 3 bubble indicators
+        CGFloat indicatorWidth = self.typingIndicatorView1.frame.size.width;
         
         CGFloat bubbleMarginMaximumSpacing = collectionViewWidth - bubbleWidth - bubbleMarginMinimumSpacing;
         CGFloat indicatorMarginMaximumSpacing = collectionViewWidth - indicatorWidth - indicatorMarginMinimumSpacing;
@@ -109,7 +124,123 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
     
     [self setNeedsUpdateConstraints];
     
-    self.typingIndicatorImageView.image = [[UIImage jsq_defaultTypingIndicatorImage] jsq_imageMaskedWithColor:ellipsisColor];
+    // Configure correct color and (whether/not) animated
+    [self setTypingIndicatorAnimated:animated :ellipsisColor];
+}
+
+- (void) setTypingIndicatorEllipsisColor:(UIColor*) ellipsisColor
+{
+    self.typingIndicatorView1.backgroundColor = ellipsisColor;
+    self.typingIndicatorView2.backgroundColor = ellipsisColor;
+    self.typingIndicatorView3.backgroundColor = ellipsisColor;
+}
+
+- (void) setTypingIndicatorAnimated:(BOOL) animated :(UIColor*) ellipsisColor
+{
+    // Configure Base Color
+    [self setTypingIndicatorEllipsisColor:ellipsisColor];
+    // Remove existing animator if exist
+    if (self.animator) {
+        [self.animator stopAnimating];
+    }
+    // If animated -> New Animator
+    if (animated) {
+        self.animator = [[JSQMessagesTypingIndicatorAnimator alloc] initWithTypingIndicatorView:self :ellipsisColor];
+        [self.animator startAnimating];
+    }
+}
+
+@end
+
+@implementation JSQMessagesTypingIndicatorAnimator
+
+- (id) initWithTypingIndicatorView:(JSQMessagesTypingIndicatorFooterView *)view :(UIColor*) ellipsisColor
+{
+    if (self = [self init]) {
+        self.typingView = view;
+        self.ellipsisColor = ellipsisColor;
+        self.animating = NO;
+        
+        // Initialize Colors
+        self.typingView.typingIndicatorView1.backgroundColor = ellipsisColor;
+        self.typingView.typingIndicatorView2.backgroundColor = ellipsisColor;
+        self.typingView.typingIndicatorView3.backgroundColor = ellipsisColor;
+    }
+    return self;
+}
+
+- (void) startAnimating
+{
+    self.animating = YES;
+    [self startTypingIndicatorAnimating:self.ellipsisColor];
+}
+
+- (void) stopAnimating
+{
+    self.animating = NO;
+}
+
+// How long does each individual dot stay dark for?
+#define kTypingIndicatorSingleDot_Darker_AnimationDuration 1.5f
+// How long does it take to transition from one dark circle to another?
+#define kTypingIndicatorSingleDot_TransitionTime 0.4f
+// Darkening co-efficient
+#define kTypingIndicatorAnimatedDot_Darkening_Coefficient 3.0f
+
+- (void) startTypingIndicatorAnimating:(UIColor*) ellipseColor {
+    [self startTypingIndicatorAnimating:0 :@[self.typingView.typingIndicatorView1, self.typingView.typingIndicatorView2, self.typingView.typingIndicatorView3] :ellipseColor :[ellipseColor jsq_colorByDarkeningColorWithValue:kTypingIndicatorAnimatedDot_Darkening_Coefficient]];
+}
+
+- (void) startTypingIndicatorAnimating:(int) typingIndex :(NSArray*)indicatorViews :(UIColor*)ellipseColor :(UIColor*)darkerEllipseColor {
+    if (!self.animating) {
+        // Exit
+        return;
+    }
+    // Which one is dark now?
+    __block int index = typingIndex % 3;
+    int otherIndex1 = (index + 1) % 3;
+    int otherIndex2 = (index + 2) % 3;
+    
+    __block UIView *darkerView = indicatorViews[index];
+    __block UIView *lighterView1 = indicatorViews[otherIndex1];
+    __block UIView *lighterView2 = indicatorViews[otherIndex2];
+    
+    [UIView animateWithDuration:kTypingIndicatorSingleDot_TransitionTime animations:^{
+        // Darker
+        darkerView.backgroundColor = darkerEllipseColor;
+        // Lighter
+        lighterView1.backgroundColor = ellipseColor;
+        lighterView2.backgroundColor = ellipseColor;
+        
+    } completion:^(BOOL finished) {
+        // Wait
+        [UIView animateWithDuration:kTypingIndicatorSingleDot_Darker_AnimationDuration animations:^{
+            // None
+        } completion:^(BOOL finished) {
+            [self startTypingIndicatorAnimating:++index :indicatorViews :ellipseColor :darkerEllipseColor];
+        }];
+    }];
+}
+
+
+
+@end
+
+
+@implementation JSQMessagesTypingIndicatorCircleView
+
+-(id) init {
+    if (self = [super init]) {
+        // Configure Circle
+    }
+    return self;
+}
+
+- (void) setFrame:(CGRect)frame
+{
+    [super setFrame:frame];
+    // Update Radius
+    self.layer.cornerRadius = frame.size.height / 2.0f;
 }
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.xib
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -18,25 +18,44 @@
                         <constraint firstAttribute="width" constant="68" id="nS4-br-DxL"/>
                     </constraints>
                 </imageView>
-                <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Vwf-dy-PS6" userLabel="Ellipsis Image View">
-                    <rect key="frame" x="26" y="6" width="34" height="34"/>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5aZ-BT-PbP" customClass="JSQMessagesTypingIndicatorCircleView">
+                    <rect key="frame" x="21" y="19" width="9" height="9"/>
+                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="34" id="CMT-z0-hca"/>
-                        <constraint firstAttribute="height" constant="34" id="j0C-FV-2gV"/>
+                        <constraint firstAttribute="height" constant="9" id="5Y9-dJ-dWe"/>
+                        <constraint firstAttribute="width" constant="9" id="M2b-xh-H6o"/>
                     </constraints>
-                </imageView>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="MLD-IF-Um9" customClass="JSQMessagesTypingIndicatorCircleView">
+                    <rect key="frame" x="36" y="19" width="9" height="9"/>
+                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                </view>
+                <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mVq-Jz-hS2" customClass="JSQMessagesTypingIndicatorCircleView">
+                    <rect key="frame" x="51" y="19" width="9" height="9"/>
+                    <color key="backgroundColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                </view>
             </subviews>
             <constraints>
-                <constraint firstAttribute="trailing" secondItem="Vwf-dy-PS6" secondAttribute="trailing" constant="260" id="1Tm-qD-wIK"/>
+                <constraint firstItem="mVq-Jz-hS2" firstAttribute="width" secondItem="5aZ-BT-PbP" secondAttribute="width" id="7Uv-8g-jaC"/>
                 <constraint firstAttribute="bottom" secondItem="Z1D-Tr-HPK" secondAttribute="bottom" constant="6" id="EVf-Sx-8mX"/>
-                <constraint firstAttribute="bottom" secondItem="Vwf-dy-PS6" secondAttribute="bottom" constant="6" id="Hik-Wl-aK2"/>
+                <constraint firstItem="5aZ-BT-PbP" firstAttribute="centerY" secondItem="ajJ-uk-b04" secondAttribute="centerY" id="Nw6-Vg-Wlz"/>
+                <constraint firstItem="mVq-Jz-hS2" firstAttribute="leading" secondItem="MLD-IF-Um9" secondAttribute="trailing" constant="6" id="O5a-oi-B9M"/>
+                <constraint firstItem="mVq-Jz-hS2" firstAttribute="height" secondItem="5aZ-BT-PbP" secondAttribute="height" id="PIO-7q-khN"/>
+                <constraint firstItem="mVq-Jz-hS2" firstAttribute="centerY" secondItem="ajJ-uk-b04" secondAttribute="centerY" id="Tex-tX-HbU"/>
+                <constraint firstItem="MLD-IF-Um9" firstAttribute="leading" secondItem="5aZ-BT-PbP" secondAttribute="trailing" constant="6" id="VNN-ZC-I5l"/>
+                <constraint firstItem="MLD-IF-Um9" firstAttribute="height" secondItem="5aZ-BT-PbP" secondAttribute="height" id="W22-Li-EUK"/>
                 <constraint firstAttribute="trailing" secondItem="Z1D-Tr-HPK" secondAttribute="trailing" constant="246" id="YMl-ej-UZl"/>
+                <constraint firstItem="MLD-IF-Um9" firstAttribute="centerY" secondItem="ajJ-uk-b04" secondAttribute="centerY" id="mUL-rD-2ip"/>
+                <constraint firstItem="MLD-IF-Um9" firstAttribute="width" secondItem="5aZ-BT-PbP" secondAttribute="width" id="pd0-zt-Tqc"/>
+                <constraint firstAttribute="trailing" secondItem="5aZ-BT-PbP" secondAttribute="trailing" constant="290" id="ubK-cK-G4Q"/>
             </constraints>
             <connections>
                 <outlet property="bubbleImageView" destination="Z1D-Tr-HPK" id="WpE-rP-oYB"/>
                 <outlet property="bubbleImageViewRightHorizontalConstraint" destination="YMl-ej-UZl" id="Thu-7D-dhU"/>
-                <outlet property="typingIndicatorImageView" destination="Vwf-dy-PS6" id="wQA-Pe-rx6"/>
-                <outlet property="typingIndicatorImageViewRightHorizontalConstraint" destination="1Tm-qD-wIK" id="FUp-oC-c0I"/>
+                <outlet property="typingIndicatorImageViewRightHorizontalConstraint" destination="ubK-cK-G4Q" id="Lxe-32-37r"/>
+                <outlet property="typingIndicatorView1" destination="5aZ-BT-PbP" id="D5n-Vr-qcy"/>
+                <outlet property="typingIndicatorView2" destination="MLD-IF-Um9" id="4Ie-H1-NQ3"/>
+                <outlet property="typingIndicatorView3" destination="mVq-Jz-hS2" id="tFs-RE-tAr"/>
             </connections>
         </collectionReusableView>
     </objects>

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.xib
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9532" systemVersion="15D21" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9530"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>

--- a/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Pods/Pods.xcodeproj/project.pbxproj
@@ -274,7 +274,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0730;
+				LastUpgradeCheck = 0700;
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -495,7 +495,6 @@
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
-				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ See the [Getting Started](https://github.com/jessesquires/JSQMessagesViewControl
 
 Read the docs, [available here][docsLink] via [@CocoaDocs](https://twitter.com/CocoaDocs).
 
+## Core team
+
+- Jesse Squries ([**@jesse_squires**](https://twitter.com/jesse_squires))
+- Harlan Haskans ([**@harlanhaskins**](https://github.com/harlanhaskins))
+- Eli Burke ([**@eliburke**](https://github.com/eliburke))
+
 ## Contributing
 
 Please follow these sweet [contribution guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md).
@@ -75,7 +81,7 @@ Support the development of this **free** library! **[Send cash](https://cash.me/
 
 ## Apps using this library
 
-According to [CocoaPods stats](https://cocoapods.org/pods/JSQMessagesViewController), over **6,000 apps** are using `JSQMessagesViewController`. [Here are the ones](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/Documentation/apps_using_this_library.md) that we know about. Please submit a [pull request](https://github.com/jessesquires/JSQMessagesViewController/compare) to add your app! :smile:
+According to [CocoaPods stats](https://cocoapods.org/pods/JSQMessagesViewController), over **8,000 apps** are using `JSQMessagesViewController`. [Here are the ones](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/Documentation/apps_using_this_library.md) that we know about. Please submit a [pull request](https://github.com/jessesquires/JSQMessagesViewController/compare) to add your app! :smile:
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Read the docs, [available here][docsLink] via [@CocoaDocs](https://twitter.com/C
 
 ## Core team
 
-- Jesse Squries ([**@jesse_squires**](https://twitter.com/jesse_squires))
+- Jesse Squires ([**@jesse_squires**](https://twitter.com/jesse_squires))
 - Harlan Haskans ([**@harlanhaskins**](https://github.com/harlanhaskins))
 - Eli Burke ([**@eliburke**](https://github.com/eliburke))
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have squashed my commits into 1 commit.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: __:muscle::sunglasses::facepunch:__

#### This fixes issue #1382 

## What's in this pull request?

Adding a configurable property to JSQMessagesViewController controlling whether the typing indicator gets the new animated behavior.  Default is NO, adhearing to previous behavior.
Updating Unit Tests to assert default "NO" values