### PR TITLE
Added a label method (for a text string or view) to JSQMediaItem

### DIFF
--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		547332D91CAC59C20069D7FC /* JSQMessagesMediaItemLabelFactory.m in Sources */ = {isa = PBXBuildFile; fileRef = 547332D81CAC59C20069D7FC /* JSQMessagesMediaItemLabelFactory.m */; };
 		88078A9D19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m in Sources */ = {isa = PBXBuildFile; fileRef = 88078A9C19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m */; };
 		88324C3419F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88324C3319F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m */; };
 		883C11781A09FB100092A16D /* JSQMessagesCellTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 883C11771A09FB100092A16D /* JSQMessagesCellTextView.m */; };
@@ -123,6 +124,8 @@
 		0B4D05069814EB50FB0F4229 /* Pods-JSQMessagesTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.release.xcconfig"; sourceTree = "<group>"; };
 		1D4D3B82D90888BCEAF890D3 /* Pods-JSQMessagesTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-JSQMessagesTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-JSQMessagesTests/Pods-JSQMessagesTests.debug.xcconfig"; sourceTree = "<group>"; };
 		3BA6237809BE0D008CFE3697 /* Pods.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.debug.xcconfig; path = "Pods/Target Support Files/Pods/Pods.debug.xcconfig"; sourceTree = "<group>"; };
+		547332D71CAC59C20069D7FC /* JSQMessagesMediaItemLabelFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JSQMessagesMediaItemLabelFactory.h; path = ../Layout/JSQMessagesMediaItemLabelFactory.h; sourceTree = "<group>"; };
+		547332D81CAC59C20069D7FC /* JSQMessagesMediaItemLabelFactory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JSQMessagesMediaItemLabelFactory.m; path = ../Layout/JSQMessagesMediaItemLabelFactory.m; sourceTree = "<group>"; };
 		88078A9B19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesMediaPlaceholderView.h; sourceTree = "<group>"; };
 		88078A9C19D8FEB5005B4595 /* JSQMessagesMediaPlaceholderView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaPlaceholderView.m; sourceTree = "<group>"; };
 		88324C3319F6301C00BC732D /* JSQMessagesMediaViewBubbleImageMaskerTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaViewBubbleImageMaskerTests.m; sourceTree = "<group>"; };
@@ -464,6 +467,8 @@
 				88A25F6719D8E01A00924534 /* JSQMessagesAvatarImageFactory.m */,
 				88A25F6819D8E01A00924534 /* JSQMessagesBubbleImageFactory.h */,
 				88A25F6919D8E01A00924534 /* JSQMessagesBubbleImageFactory.m */,
+				547332D71CAC59C20069D7FC /* JSQMessagesMediaItemLabelFactory.h */,
+				547332D81CAC59C20069D7FC /* JSQMessagesMediaItemLabelFactory.m */,
 				88C4582E19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.h */,
 				88C4582F19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m */,
 				88A25F6A19D8E01A00924534 /* JSQMessagesTimestampFormatter.h */,
@@ -860,6 +865,7 @@
 				88A25FC119D8E01A00924534 /* JSQMessagesCollectionViewFlowLayout.m in Sources */,
 				8885734A19DE540400E89D20 /* DemoSettingsViewController.m in Sources */,
 				88A25FC719D8E01A00924534 /* JSQMessagesBubbleImage.m in Sources */,
+				547332D91CAC59C20069D7FC /* JSQMessagesMediaItemLabelFactory.m in Sources */,
 				88A25FC519D8E01A00924534 /* JSQMessage.m in Sources */,
 				88A25FD719D8E01A00924534 /* JSQMessagesTypingIndicatorFooterView.m in Sources */,
 				88A25FD319D8E01A00924534 /* JSQMessagesLoadEarlierHeaderView.m in Sources */,

--- a/JSQMessagesDemo/DemoModelData.m
+++ b/JSQMessagesDemo/DemoModelData.m
@@ -159,6 +159,7 @@
 - (void)addPhotoMediaMessage
 {
     JSQPhotoMediaItem *photoItem = [[JSQPhotoMediaItem alloc] initWithImage:[UIImage imageNamed:@"goldengate"]];
+    photoItem.mediaLabelText = @"goldengate.png";
     JSQMessage *photoMessage = [JSQMessage messageWithSenderId:kJSQDemoAvatarIdSquires
                                                    displayName:kJSQDemoAvatarDisplayNameSquires
                                                          media:photoItem];

--- a/JSQMessagesDemo/DemoModelData.m
+++ b/JSQMessagesDemo/DemoModelData.m
@@ -20,6 +20,11 @@
 
 #import "NSUserDefaults+DemoSettings.h"
 
+@interface DemoModelData()
+
+@property (retain, nonatomic) JSQMessagesMediaItemLabelFactory * labelFactory;
+
+@end
 
 /**
  *  This is for demo/testing purposes only.
@@ -33,7 +38,9 @@
 {
     self = [super init];
     if (self) {
-        
+
+        self.labelFactory = [[JSQMessagesMediaItemLabelFactory alloc] init];
+
         if ([NSUserDefaults emptyMessagesSetting]) {
             self.messages = [NSMutableArray new];
         }
@@ -160,6 +167,7 @@
 {
     JSQPhotoMediaItem *photoItem = [[JSQPhotoMediaItem alloc] initWithImage:[UIImage imageNamed:@"goldengate"]];
     photoItem.mediaLabelText = @"goldengate.png";
+    photoItem.mediaLabelFactory = self.labelFactory;
     JSQMessage *photoMessage = [JSQMessage messageWithSenderId:kJSQDemoAvatarIdSquires
                                                    displayName:kJSQDemoAvatarDisplayNameSquires
                                                          media:photoItem];

--- a/JSQMessagesViewController/JSQMessages.h
+++ b/JSQMessagesViewController/JSQMessages.h
@@ -62,6 +62,7 @@
 //  Factories
 #import "JSQMessagesAvatarImageFactory.h"
 #import "JSQMessagesBubbleImageFactory.h"
+#import "JSQMessagesMediaItemLabelFactory.h"
 #import "JSQMessagesMediaViewBubbleImageMasker.h"
 #import "JSQMessagesTimestampFormatter.h"
 #import "JSQMessagesToolbarButtonFactory.h"

--- a/JSQMessagesViewController/Layout/JSQMessagesMediaItemLabelFactory.h
+++ b/JSQMessagesViewController/Layout/JSQMessagesMediaItemLabelFactory.h
@@ -1,0 +1,148 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+//
+//  Ideas for springy collection view layout taken from Ash Furrow
+//  ASHSpringyCollectionView
+//  https://github.com/AshFurrow/ASHSpringyCollectionView
+//
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
+typedef NS_ENUM(NSInteger, JSQMediaLabelPosition) {
+    JSQMediaLabelPositionTop,
+    JSQMediaLabelPositionLeft,
+    JSQMediaLabelPositionBottom,
+    JSQMediaLabelPositionRight
+};
+
+@interface JSQMessagesMediaItemLabelFactory : NSObject
+
+/**
+ * Creates and returns a new instance of `JSQMessagesMediaItemLabelFactory` that uses
+ * default colors, effects, and frame+insets based on the location
+ *
+ * @return An initialized `JSQMessagesMediaItemLabelFactory` object if created successfully, `nil` otherwise.
+ */
+- (instancetype)initWithPosition:(JSQMediaLabelPosition)position;
+
+/**
+ * Convenience initializer that returns a new `JSQMessagesMediaItemLabelFactory`
+ * configured for labels at the bottom of the media view (`JSQMediaLabelPositionBottom`)
+ *
+ * @return An initialized `JSQMessagesMediaItemLabelFactory` object if created successfully, `nil` otherwise.
+ */
+- (instancetype)init;
+
+/**
+ * Location to place the label subview.
+ * Left and Right probably don't make sense unless using a custom label.
+ * Defaults to JSQMediaLabelLocationBottom.
+ */
+@property (nonatomic) JSQMediaLabelPosition labelPosition;
+
+/**
+ * The font to use for text labels
+ * Defaults to systemFontOfSize:16
+ */
+@property (assign, nonatomic) UIFont * labelFont;
+
+/**
+ *  The foreground color to use for text labels
+ * Defaults to `blackColor`
+ */
+@property (assign, nonatomic) UIColor * labelTextColor;
+
+/**
+ *  The maximum width of a text label
+ * Defaults to `0` (no maximum enforced, up to the media view width)
+ */
+@property (assign, nonatomic) CGFloat labelMaxWidth;
+
+/**
+ *  The maximum height of a text label
+ * Defaults to `0` (no maximum enforced, up to the media view height)
+ */
+@property (assign, nonatomic) CGFloat labelMaxHeight;
+
+/**
+ *  The text label line break mode (if text is too long to fit)
+ * Defaults to `NSLineBreakByTruncatingTail`
+ */
+@property (assign, nonatomic) NSLineBreakMode labelLineBreakMode;
+
+/**
+ *  The text label line break mode (if text is too long to fit)
+ * Defaults to `NSTextAlignmentLeft` when position is Top or Bottom,
+ * or to `NSTextAlignmentCenter` when position is Left or Right
+ */
+@property (assign, nonatomic) NSTextAlignment labelTextAlignment;
+
+/**
+ * Vertically center the text label when position is Top or Bottom
+ * Defaults to `YES`
+ */
+@property (nonatomic) BOOL labelVerticalCenter;
+
+/**
+ * The background color to use for text labels
+ * Defaults to `clearColor`. Other values may obscure blur/vibrancy effects
+ */
+@property (assign, nonatomic) UIColor * labelTextBackgroundColor;
+
+/**
+ * Insets to use for text labels
+ * Defaults to `UIEdgeInsetsMake(4, 8, 8, 6)`.
+ */
+@property (assign, nonatomic) UIEdgeInsets labelTextInsets;
+
+/**
+ * Use blur effects under text labels.
+ * Defaults to YES
+ */
+@property (nonatomic) BOOL useBlurEffect;
+
+/**
+ * Desired blur effect, if enabled.
+ * Defaults to UIBlurEffectStyleExtraLight
+ */
+@property (nonatomic) UIBlurEffectStyle blurEffectStyle;
+
+/**
+ * Use vibrancy effects overtop of blur effects. Subviews must be `tintColorDidChange` aware to work properly.
+ * Defaults to NO
+ */
+@property (nonatomic) BOOL useVibrancyEffect;
+
+/**
+ * Use blur and vibrancy effects settings for custom views.
+ * Defaults to NO
+ */
+@property (nonatomic) BOOL useEffectsOnCustomViews;
+
+/**
+ * Add a text label using currently configured properties to the media view
+ */
+- (void)addLabel:(NSString*)text mediaView:(UIView *)mediaView;
+
+/**
+ * Add a custom view (using relevant properties) to the media view
+ */
+- (void)addCustomView:(UIView *)customView mediaView:(UIView *)mediaView;
+
+@end

--- a/JSQMessagesViewController/Layout/JSQMessagesMediaItemLabelFactory.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesMediaItemLabelFactory.m
@@ -1,0 +1,187 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+//
+//  Ideas for springy collection view layout taken from Ash Furrow
+//  ASHSpringyCollectionView
+//  https://github.com/AshFurrow/ASHSpringyCollectionView
+//
+
+#import "JSQMessagesMediaItemLabelFactory.h"
+
+@implementation JSQMessagesMediaItemLabelFactory
+
+- (instancetype)init {
+    return [self initWithPosition:JSQMediaLabelPositionBottom];
+}
+
+- (instancetype)initWithPosition:(JSQMediaLabelPosition)position {
+    self = [super init];
+    if (self) {
+        self.labelPosition = position;
+        
+        if (position == JSQMediaLabelPositionLeft) {
+            self.labelTextInsets = UIEdgeInsetsMake(6, 8, 6, 6);
+            self.labelTextAlignment = NSTextAlignmentCenter;
+            self.labelVerticalCenter = YES;
+        } else if (position == JSQMediaLabelPositionRight) {
+            self.labelTextInsets = UIEdgeInsetsMake(6, 6, 6, 10);
+            self.labelTextAlignment = NSTextAlignmentCenter;
+            self.labelVerticalCenter = YES;
+        } else { // JSQMediaLabelPositionTop, JSQMediaLabelPositionBottom
+            self.labelTextInsets = UIEdgeInsetsMake(4, 8, 8, 6);
+            self.labelTextAlignment = NSTextAlignmentLeft;
+        }
+
+        self.labelFont = [UIFont systemFontOfSize:16];
+        self.labelTextColor = [UIColor blackColor];
+        self.labelTextBackgroundColor = [UIColor clearColor];
+        
+        self.labelMaxWidth = 0;
+        self.labelMaxHeight = 0;
+        self.labelLineBreakMode = NSLineBreakByTruncatingTail;
+        
+        self.blurEffectStyle = UIBlurEffectStyleExtraLight;
+        self.useBlurEffect = YES;
+        self.useVibrancyEffect = NO;
+        self.useEffectsOnCustomViews = NO;
+    }
+    return self;
+}
+
+- (void)addCustomView:(UIView *)customView mediaView:(UIView *)mediaView
+{
+    [self createLabel:customView
+          onMediaView:mediaView
+              addBlur:self.useEffectsOnCustomViews ? self.useBlurEffect : NO];
+}
+
+- (void)addLabel:(NSString*)text mediaView:(UIView *)mediaView
+{
+
+    UITextView * labelView = [[UITextView alloc] init];
+    
+    labelView.text = text;
+    labelView.scrollEnabled = NO;
+    labelView.font = self.labelFont;
+    
+    labelView.textColor = self.labelTextColor;
+    labelView.backgroundColor = self.labelTextBackgroundColor;
+    labelView.textAlignment = self.labelTextAlignment;
+    labelView.textContainer.lineBreakMode = self.labelLineBreakMode;
+    
+    // constrain the width/height of the initial bounding rect according to maximum width/height
+    CGSize constraintSize = mediaView.frame.size;
+    if (self.labelMaxWidth)
+        constraintSize.width = fmin(constraintSize.width, self.labelMaxWidth);
+    if (self.labelMaxHeight)
+        constraintSize.height = fmin(constraintSize.height, self.labelMaxHeight);
+    
+    // subtract text insets and the fragment padding that will affect line breaks
+    constraintSize.width -= (self.labelTextInsets.left + self.labelTextInsets.right + (2 * labelView.textContainer.lineFragmentPadding));
+    constraintSize.height -= (self.labelTextInsets.top + self.labelTextInsets.bottom);
+
+    // calculate the actual text frame as determined by the constraintSize
+    CGRect boundingRect = [text boundingRectWithSize:constraintSize
+                                                  options: NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingUsesFontLeading
+                                               attributes: @{NSFontAttributeName : self.labelFont}
+                                                  context: NULL];
+
+    // build the final label frame, pinning the width or height according to the label orientation
+    CGRect labelFrame = CGRectZero;
+    if (self.labelPosition == JSQMediaLabelPositionLeft ||
+        self.labelPosition == JSQMediaLabelPositionRight)
+    {
+        labelFrame.size.height = mediaView.frame.size.height;
+        labelFrame.size.width = ceil(boundingRect.size.width +
+                                     self.labelTextInsets.left + self.labelTextInsets.right +
+                                     (2 *labelView.textContainer.lineFragmentPadding));
+    } else {
+        labelFrame.size.height = ceil(boundingRect.size.height +
+                                      self.labelTextInsets.top + self.labelTextInsets.bottom);
+        labelFrame.size.width = mediaView.frame.size.width;
+    }
+    
+    // constrain the width/height of the final label rect
+    if (self.labelMaxWidth && self.labelMaxWidth < labelFrame.size.width)
+        labelFrame.size.width = fmin(labelFrame.size.width, self.labelMaxWidth);
+    if (self.labelMaxHeight && self.labelMaxHeight < labelFrame.size.height)
+        labelFrame.size.height = fmin(labelFrame.size.height, self.labelMaxHeight);
+    
+    // optional vertical centering of the label text
+    if (self.labelVerticalCenter && boundingRect.size.height < labelFrame.size.height) {
+        UIEdgeInsets textInsets = self.labelTextInsets;
+        CGFloat slack = labelFrame.size.height - boundingRect.size.height - textInsets.top - textInsets.bottom;
+        if (slack > 0)
+            textInsets.top += round(slack / 2);
+        labelView.textContainerInset = textInsets;
+    } else {
+        labelView.textContainerInset = self.labelTextInsets;
+    }
+
+    labelView.frame = labelFrame;
+
+    [self createLabel:labelView onMediaView:mediaView addBlur:self.useBlurEffect];
+}
+
+#pragma mark -- Private
+
+- (void)createLabel:(UIView *)labelView onMediaView:(UIView *)mediaView addBlur:(BOOL)addBlur
+{
+    // calculate a frame to put the label at the top or bottom of the view
+    CGRect labelFrame = mediaView.bounds;
+    if (self.labelPosition == JSQMediaLabelPositionTop) {
+        labelFrame.size.height = labelView.frame.size.height;
+    } else if (self.labelPosition == JSQMediaLabelPositionLeft) {
+        labelFrame.size.width = labelView.frame.size.width;
+    } else if (self.labelPosition == JSQMediaLabelPositionRight) {
+        labelFrame.origin.x = labelFrame.size.width - labelView.frame.size.width;
+        labelFrame.size.width = labelView.frame.size.width;
+    } else { // JSQMediaLabelPositionBottom
+        labelFrame.origin.y = labelFrame.size.height - labelView.frame.size.height;
+        labelFrame.size.height = labelView.frame.size.height;
+    }
+    
+    if (self.labelMaxWidth)
+        labelFrame.size.width = fmin(labelFrame.size.width, self.labelMaxWidth);
+    if (self.labelMaxHeight)
+        labelFrame.size.height = fmin(labelFrame.size.height, self.labelMaxHeight);
+
+    // add blur / vibrancy effects
+    if (addBlur) {
+        UIBlurEffect * blur = [UIBlurEffect effectWithStyle:self.blurEffectStyle];
+        UIVisualEffectView * blurView = [[UIVisualEffectView alloc]initWithEffect:blur];
+        blurView.frame = labelFrame;
+        labelView.frame = blurView.bounds;
+
+        if (self.useVibrancyEffect) {
+            UIVibrancyEffect * vibrancy = [UIVibrancyEffect effectForBlurEffect:blur];
+            UIVisualEffectView * vibrancyView = [[UIVisualEffectView alloc] initWithEffect:vibrancy];
+            vibrancyView.frame = blurView.bounds;
+            [blurView.contentView addSubview:vibrancyView];
+            [vibrancyView.contentView addSubview:labelView];
+        } else {
+            [blurView.contentView addSubview:labelView];
+        }
+        [mediaView addSubview:blurView];
+    } else {
+        labelView.frame = labelFrame;
+        [mediaView addSubview:labelView];
+    }
+}
+
+@end

--- a/JSQMessagesViewController/Model/JSQMediaItem.h
+++ b/JSQMessagesViewController/Model/JSQMediaItem.h
@@ -41,6 +41,16 @@
 @property (assign, nonatomic) BOOL appliesMediaViewMaskAsOutgoing;
 
 /**
+ *  A string value that is applied as a label at the bottom of the media view
+ */
+@property (strong, nonatomic) NSString * mediaLabelText;
+
+/**
+ *  A custom view that is added as a subview at the bottom of the media view
+ */
+@property (strong, nonatomic) UIView * mediaLabelView;
+
+/**
  *  Initializes and returns a media item with the specified value for maskAsOutgoing.
  *
  *  @param maskAsOutgoing A boolean value indicating whether this media item should apply
@@ -54,5 +64,9 @@
  *  Clears any media view or media placeholder view that the item has cached.
  */
 - (void)clearCachedMediaViews;
+
++ (void)addLabelView:(UIView *)labelView toMediaView:(UIView *)mediaView blurredBackground:(BOOL)blurred;
+
++ (void)addLabelText:(NSString*)labelText toMediaView:(UIView *)mediaView font:(UIFont*)font insets:(UIEdgeInsets)insets;
 
 @end

--- a/JSQMessagesViewController/Model/JSQMediaItem.h
+++ b/JSQMessagesViewController/Model/JSQMediaItem.h
@@ -17,6 +17,7 @@
 //
 
 #import "JSQMessageMediaData.h"
+#import "JSQMessagesMediaItemLabelFactory.h"
 
 /**
  *  The `JSQMediaItem` class is an abstract base class for media item model objects that represents
@@ -41,12 +42,19 @@
 @property (assign, nonatomic) BOOL appliesMediaViewMaskAsOutgoing;
 
 /**
- *  A string value that is applied as a label at the bottom of the media view
+ *  A label factory object that is used to render label text or a label view
+ *  Defaults to `nil`
+ */
+@property (assign, nonatomic) JSQMessagesMediaItemLabelFactory * mediaLabelFactory;
+
+/**
+ *  A string value that is transformed to a UITextView and applied to the
+ *  mediaView by the mediaLabelFactory object
  */
 @property (strong, nonatomic) NSString * mediaLabelText;
 
 /**
- *  A custom view that is added as a subview at the bottom of the media view
+ *  A custom view that is applied to the mediaView by the mediaLabelFactory object
  */
 @property (strong, nonatomic) UIView * mediaLabelView;
 
@@ -64,9 +72,5 @@
  *  Clears any media view or media placeholder view that the item has cached.
  */
 - (void)clearCachedMediaViews;
-
-+ (void)addLabelView:(UIView *)labelView toMediaView:(UIView *)mediaView blurredBackground:(BOOL)blurred;
-
-+ (void)addLabelText:(NSString*)labelText toMediaView:(UIView *)mediaView font:(UIFont*)font insets:(UIEdgeInsets)insets;
 
 @end

--- a/JSQMessagesViewController/Model/JSQMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQMediaItem.m
@@ -83,6 +83,46 @@
     return nil;
 }
 
++ (void)addLabelView:(UIView *)labelView toMediaView:(UIView *)mediaView blurredBackground:(BOOL)blurred
+{
+    CGRect effectFrame = mediaView.bounds;
+    effectFrame.origin.y = effectFrame.size.height - labelView.frame.size.height;
+    effectFrame.size.height = labelView.frame.size.height;
+    
+    // add effect to an effect view
+    UIBlurEffect * blur = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
+    UIVisualEffectView * effectView = [[UIVisualEffectView alloc]initWithEffect:blur];
+    effectView.frame = effectFrame;
+    [effectView addSubview:labelView];
+    
+    // add the effect view to the image view
+    [mediaView addSubview:effectView];
+}
+
++ (void)addLabelText:(NSString*)labelText toMediaView:(UIView *)mediaView font:(UIFont*)font insets:(UIEdgeInsets)insets
+{
+    UIEdgeInsets internalInsets = UIEdgeInsetsMake(4, 8, 8, 6);
+    if (! UIEdgeInsetsEqualToEdgeInsets(insets, UIEdgeInsetsZero))
+        internalInsets = insets;
+    
+    CGRect labelFrame = mediaView.bounds;
+    labelFrame.size.height = 24;
+    UITextView * labelView = [[UITextView alloc] initWithFrame:labelFrame];
+    labelView.textContainerInset = internalInsets;
+    labelView.backgroundColor = [UIColor clearColor];
+    labelView.textColor = [UIColor blackColor];
+    labelView.text = labelText;
+    if (font) {
+        labelView.font = font;
+    }
+    
+    CGSize textSize = [labelView.text sizeWithAttributes:@{NSFontAttributeName:[labelView font]}];
+    labelFrame.size.height = textSize.height + internalInsets.top + internalInsets.bottom;
+    labelView.frame = labelFrame;
+    
+    [self addLabelView:labelView toMediaView:mediaView blurredBackground:YES];
+}
+
 - (CGSize)mediaViewDisplaySize
 {
     if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {

--- a/JSQMessagesViewController/Model/JSQMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQMediaItem.m
@@ -83,46 +83,6 @@
     return nil;
 }
 
-+ (void)addLabelView:(UIView *)labelView toMediaView:(UIView *)mediaView blurredBackground:(BOOL)blurred
-{
-    CGRect effectFrame = mediaView.bounds;
-    effectFrame.origin.y = effectFrame.size.height - labelView.frame.size.height;
-    effectFrame.size.height = labelView.frame.size.height;
-    
-    // add effect to an effect view
-    UIBlurEffect * blur = [UIBlurEffect effectWithStyle:UIBlurEffectStyleExtraLight];
-    UIVisualEffectView * effectView = [[UIVisualEffectView alloc]initWithEffect:blur];
-    effectView.frame = effectFrame;
-    [effectView addSubview:labelView];
-    
-    // add the effect view to the image view
-    [mediaView addSubview:effectView];
-}
-
-+ (void)addLabelText:(NSString*)labelText toMediaView:(UIView *)mediaView font:(UIFont*)font insets:(UIEdgeInsets)insets
-{
-    UIEdgeInsets internalInsets = UIEdgeInsetsMake(4, 8, 8, 6);
-    if (! UIEdgeInsetsEqualToEdgeInsets(insets, UIEdgeInsetsZero))
-        internalInsets = insets;
-    
-    CGRect labelFrame = mediaView.bounds;
-    labelFrame.size.height = 24;
-    UITextView * labelView = [[UITextView alloc] initWithFrame:labelFrame];
-    labelView.textContainerInset = internalInsets;
-    labelView.backgroundColor = [UIColor clearColor];
-    labelView.textColor = [UIColor blackColor];
-    labelView.text = labelText;
-    if (font) {
-        labelView.font = font;
-    }
-    
-    CGSize textSize = [labelView.text sizeWithAttributes:@{NSFontAttributeName:[labelView font]}];
-    labelFrame.size.height = textSize.height + internalInsets.top + internalInsets.bottom;
-    labelView.frame = labelFrame;
-    
-    [self addLabelView:labelView toMediaView:mediaView blurredBackground:YES];
-}
-
 - (CGSize)mediaViewDisplaySize
 {
     if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {

--- a/JSQMessagesViewController/Model/JSQPhotoMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQPhotoMediaItem.m
@@ -81,10 +81,12 @@
         self.cachedImageView = imageView;
     }
     
-    if (self.mediaLabelText) {
-        [[self class] addLabelText:self.mediaLabelText toMediaView:self.cachedImageView font:[UIFont systemFontOfSize:16] insets:UIEdgeInsetsZero];
-    } else if (self.mediaLabelView) {
-        [[self class] addLabelView:self.mediaLabelView toMediaView:self.cachedImageView blurredBackground:YES];
+    if (self.mediaLabelFactory) {
+        if (self.mediaLabelText) {
+            [self.mediaLabelFactory addLabel:self.mediaLabelText mediaView:self.cachedImageView];
+        } else if (self.mediaLabelView) {
+            [self.mediaLabelFactory addCustomView:self.mediaLabelView mediaView:self.cachedImageView];
+        }
     }
     
     return self.cachedImageView;

--- a/JSQMessagesViewController/Model/JSQPhotoMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQPhotoMediaItem.m
@@ -81,6 +81,12 @@
         self.cachedImageView = imageView;
     }
     
+    if (self.mediaLabelText) {
+        [[self class] addLabelText:self.mediaLabelText toMediaView:self.cachedImageView font:[UIFont systemFontOfSize:16] insets:UIEdgeInsetsZero];
+    } else if (self.mediaLabelView) {
+        [[self class] addLabelView:self.mediaLabelView toMediaView:self.cachedImageView blurredBackground:YES];
+    }
+    
     return self.cachedImageView;
 }
 


### PR DESCRIPTION
I love iMessage, but Facebook's Messenger definitely iterates at a faster pace. I like the labels they put on their media items, so I threw this together (over a glass of red wine so YMMV).
Call `JSQMediaItem:addLabelText` or `JSQMediaItem:addLabelView` from any subclass to put a label banner across the bottom of your media items. 

<img width="375" alt="screen shot 2016-03-29 at 10 20 39 pm" src="https://cloud.githubusercontent.com/assets/2371768/14130007/55694580-f5fd-11e5-839a-5c412a1812b4.png">

As an example, I also added mediaLabelText and mediaLabelView properties to JSQMediaItem, and updated JSQPhotoItem to look for said properties when rendering the cachedImageView. If @jessesquires likes this PR we can trivially support them on video, location, etc

If you want clickable buttons, Giphy logos, etc, create your own view and set it up any way you want. 
