### PR TITLE
Allow users to create their own views inside message bubbles.

### DIFF
--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -109,6 +109,12 @@
 		88C00A521A44D4E500B004B3 /* JSQVideoMediaItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C00A511A44D4E500B004B3 /* JSQVideoMediaItemTests.m */; };
 		88C4583019F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C4582F19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m */; };
 		BF6DA766BD3B8893A67FB2BD /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3F882AA48978C11F64DC2DF /* libPods.a */; };
+		C23060A51CBACAB6008CE938 /* JSQCustomMediaView.m in Sources */ = {isa = PBXBuildFile; fileRef = C23060A21CBACAB6008CE938 /* JSQCustomMediaView.m */; };
+		C23060A61CBACAB6008CE938 /* JSQHTMLMessageView.m in Sources */ = {isa = PBXBuildFile; fileRef = C23060A41CBACAB6008CE938 /* JSQHTMLMessageView.m */; };
+		C23060A91CBACAC2008CE938 /* JSQCustomMediaItem.m in Sources */ = {isa = PBXBuildFile; fileRef = C23060A81CBACAC2008CE938 /* JSQCustomMediaItem.m */; };
+		C23060AB1CBACDC3008CE938 /* JSQCutomMediaItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C23060AA1CBACDC3008CE938 /* JSQCutomMediaItemTests.m */; };
+		C23060AD1CBAD494008CE938 /* JSQCustomMediaViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C23060AC1CBAD494008CE938 /* JSQCustomMediaViewTests.m */; };
+		C23060AF1CBAD59F008CE938 /* JSQHTMLMessageViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = C23060AE1CBAD59F008CE938 /* JSQHTMLMessageViewTests.m */; };
 		C8994EF7DDBE74B9E3F1A16C /* libPods-JSQMessagesTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E23238C8D8DF79244DEE1787 /* libPods-JSQMessagesTests.a */; };
 		E8877F1947CE8050ECCD9539 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3F882AA48978C11F64DC2DF /* libPods.a */; };
 /* End PBXBuildFile section */
@@ -279,6 +285,15 @@
 		88C4582E19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesMediaViewBubbleImageMasker.h; sourceTree = "<group>"; };
 		88C4582F19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaViewBubbleImageMasker.m; sourceTree = "<group>"; };
 		AD6E75315517DE46FE495B65 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		C23060A11CBACAB6008CE938 /* JSQCustomMediaView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQCustomMediaView.h; sourceTree = "<group>"; };
+		C23060A21CBACAB6008CE938 /* JSQCustomMediaView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQCustomMediaView.m; sourceTree = "<group>"; };
+		C23060A31CBACAB6008CE938 /* JSQHTMLMessageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQHTMLMessageView.h; sourceTree = "<group>"; };
+		C23060A41CBACAB6008CE938 /* JSQHTMLMessageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQHTMLMessageView.m; sourceTree = "<group>"; };
+		C23060A71CBACAC2008CE938 /* JSQCustomMediaItem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQCustomMediaItem.h; sourceTree = "<group>"; };
+		C23060A81CBACAC2008CE938 /* JSQCustomMediaItem.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQCustomMediaItem.m; sourceTree = "<group>"; };
+		C23060AA1CBACDC3008CE938 /* JSQCutomMediaItemTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQCutomMediaItemTests.m; sourceTree = "<group>"; };
+		C23060AC1CBAD494008CE938 /* JSQCustomMediaViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQCustomMediaViewTests.m; sourceTree = "<group>"; };
+		C23060AE1CBAD59F008CE938 /* JSQHTMLMessageViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQHTMLMessageViewTests.m; sourceTree = "<group>"; };
 		C3F882AA48978C11F64DC2DF /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E23238C8D8DF79244DEE1787 /* libPods-JSQMessagesTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JSQMessagesTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -506,6 +521,8 @@
 		88A25F7619D8E01A00924534 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				C23060A71CBACAC2008CE938 /* JSQCustomMediaItem.h */,
+				C23060A81CBACAC2008CE938 /* JSQCustomMediaItem.m */,
 				54271E3C1C905B9200294290 /* JSQAudioMediaItem.h */,
 				54271E3D1C905B9200294290 /* JSQAudioMediaItem.m */,
 				88445B3E19E1B4470014F889 /* JSQLocationMediaItem.h */,
@@ -535,6 +552,10 @@
 		88A25F8919D8E01A00924534 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				C23060A11CBACAB6008CE938 /* JSQCustomMediaView.h */,
+				C23060A21CBACAB6008CE938 /* JSQCustomMediaView.m */,
+				C23060A31CBACAB6008CE938 /* JSQHTMLMessageView.h */,
+				C23060A41CBACAB6008CE938 /* JSQHTMLMessageView.m */,
 				883C11761A09FB100092A16D /* JSQMessagesCellTextView.h */,
 				883C11771A09FB100092A16D /* JSQMessagesCellTextView.m */,
 				88A25F8A19D8E01A00924534 /* JSQMessagesCollectionView.h */,
@@ -621,6 +642,7 @@
 				88A25FF619D8E18400924534 /* JSQMessageTextTests.m */,
 				88C00A4F1A44D4D800B004B3 /* JSQPhotoMediaItemTests.m */,
 				88C00A511A44D4E500B004B3 /* JSQVideoMediaItemTests.m */,
+				C23060AA1CBACDC3008CE938 /* JSQCutomMediaItemTests.m */,
 			);
 			path = ModelTests;
 			sourceTree = "<group>";
@@ -636,6 +658,8 @@
 				88A25FFE19D8E18400924534 /* JSQMessagesLoadEarlierHeaderViewTests.m */,
 				88A25FFF19D8E18400924534 /* JSQMessagesToolbarContentViewTests.m */,
 				88A2600019D8E18400924534 /* JSQMessagesTypingIndicatorFooterViewTests.m */,
+				C23060AC1CBAD494008CE938 /* JSQCustomMediaViewTests.m */,
+				C23060AE1CBAD59F008CE938 /* JSQHTMLMessageViewTests.m */,
 			);
 			path = ViewTests;
 			sourceTree = "<group>";
@@ -869,6 +893,7 @@
 				8885734D19DE55D000E89D20 /* NSUserDefaults+DemoSettings.m in Sources */,
 				544A32211CB2EE380084BFC0 /* JSQAudioMediaViewAttributes.m in Sources */,
 				883C11781A09FB100092A16D /* JSQMessagesCellTextView.m in Sources */,
+				C23060A51CBACAB6008CE938 /* JSQCustomMediaView.m in Sources */,
 				88A25FB919D8E01A00924534 /* UIView+JSQMessages.m in Sources */,
 				88A25FCA19D8E01A00924534 /* JSQMessagesCollectionView.m in Sources */,
 				88A25FD219D8E01A00924534 /* JSQMessagesLabel.m in Sources */,
@@ -878,6 +903,7 @@
 				88A25FC119D8E01A00924534 /* JSQMessagesCollectionViewFlowLayout.m in Sources */,
 				8885734A19DE540400E89D20 /* DemoSettingsViewController.m in Sources */,
 				88A25FC719D8E01A00924534 /* JSQMessagesBubbleImage.m in Sources */,
+				C23060A61CBACAB6008CE938 /* JSQHTMLMessageView.m in Sources */,
 				88A25FC519D8E01A00924534 /* JSQMessage.m in Sources */,
 				88A25FD719D8E01A00924534 /* JSQMessagesTypingIndicatorFooterView.m in Sources */,
 				88A25FD319D8E01A00924534 /* JSQMessagesLoadEarlierHeaderView.m in Sources */,
@@ -892,6 +918,7 @@
 				886FFD2E19E9A65D00EB8485 /* UIDevice+JSQMessages.m in Sources */,
 				88B5C41F1B7C422900EC79D4 /* JSQMessagesBubblesSizeCalculator.m in Sources */,
 				88A25FB619D8E01A00924534 /* NSString+JSQMessages.m in Sources */,
+				C23060A91CBACAC2008CE938 /* JSQCustomMediaItem.m in Sources */,
 				88A901B619F618B100F99777 /* JSQMediaItem.m in Sources */,
 				88A25FCC19D8E01A00924534 /* JSQMessagesCollectionViewCellIncoming.m in Sources */,
 				88A25FBE19D8E01A00924534 /* JSQMessagesBubbleImageFactory.m in Sources */,
@@ -925,10 +952,12 @@
 				88A2600B19D8E18400924534 /* JSQMessagesCollectionViewFlowLayoutTests.m in Sources */,
 				88A2601019D8E18400924534 /* JSQMessageTextTests.m in Sources */,
 				88A2600D19D8E18400924534 /* JSQMessageMediaTests.m in Sources */,
+				C23060AD1CBAD494008CE938 /* JSQCustomMediaViewTests.m in Sources */,
 				88A2600719D8E18400924534 /* JSQMessagesAvatarImageFactoryTests.m in Sources */,
 				88A2600419D8E18400924534 /* JSQMessagesUIViewTests.m in Sources */,
 				88A2600F19D8E18400924534 /* JSQMessagesBubbleImageTests.m in Sources */,
 				88A2600E19D8E18400924534 /* JSQMessagesAvatarImageTests.m in Sources */,
+				C23060AB1CBACDC3008CE938 /* JSQCutomMediaItemTests.m in Sources */,
 				88A2600919D8E18400924534 /* JSQMessagesTimestampFormatterTests.m in Sources */,
 				88A2601419D8E18400924534 /* JSQMessagesComposerTextViewTests.m in Sources */,
 				88A2601319D8E18400924534 /* JSQMessagesCollectionViewTests.m in Sources */,
@@ -939,6 +968,7 @@
 				88A2601919D8E18400924534 /* JSQMessagesTypingIndicatorFooterViewTests.m in Sources */,
 				88A2600319D8E18400924534 /* JSQMessagesUIImageTests.m in Sources */,
 				88C00A4E1A44D4C600B004B3 /* JSQLocationMediaItemTests.m in Sources */,
+				C23060AF1CBAD59F008CE938 /* JSQHTMLMessageViewTests.m in Sources */,
 				8873B60E1AB7B63E006DF9AC /* JSQMessagesNSBundleTests.m in Sources */,
 				88A2600C19D8E18400924534 /* JSQMessagesCollectionViewLayoutAttributesTests.m in Sources */,
 				88A2600619D8E18400924534 /* JSQMessagesViewControllerTests.m in Sources */,

--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -17,6 +17,7 @@
 //
 
 #import "DemoMessagesViewController.h"
+#import "JSQCustomMediaItem.h"
 
 @implementation DemoMessagesViewController
 
@@ -220,6 +221,12 @@
                 
                 newMediaData = videoItemCopy;
             }
+            else if ([copyMediaData isKindOfClass:[JSQCustomMediaItem class]]) {
+                JSQCustomMediaItem *customItemCopy = [((JSQCustomMediaItem *)copyMediaData) copy];
+                customItemCopy.appliesMediaViewMaskAsOutgoing = NO;
+
+                newMediaData = customItemCopy;
+            }
             else {
                 NSLog(@"%s error: unrecognized media item", __PRETTY_FUNCTION__);
             }
@@ -329,7 +336,7 @@
                                                        delegate:self
                                               cancelButtonTitle:@"Cancel"
                                          destructiveButtonTitle:nil
-                                              otherButtonTitles:@"Send photo", @"Send location", @"Send video", nil];
+                                              otherButtonTitles:@"Send photo", @"Send location", @"Send video", @"Send html", nil];
     
     [sheet showFromToolbar:self.inputToolbar];
 }
@@ -358,6 +365,9 @@
             
         case 2:
             [self.demoData addVideoMediaMessage];
+            break;
+        case 3:
+            [self.demoData addHTMLMediaMessage];
             break;
     }
     
@@ -524,7 +534,15 @@
         cell.textView.linkTextAttributes = @{ NSForegroundColorAttributeName : cell.textView.textColor,
                                               NSUnderlineStyleAttributeName : @(NSUnderlineStyleSingle | NSUnderlinePatternSolid) };
     }
-    
+    else if ([msg.media isKindOfClass:[JSQCustomMediaItem class]]) {
+        if ([msg.senderId isEqualToString:self.senderId]) {
+            ((JSQCustomMediaItem *)msg.media).preferredTextColor = [UIColor blackColor];
+        }
+        else {
+            ((JSQCustomMediaItem *)msg.media).preferredTextColor = [UIColor whiteColor];
+        }
+    }
+
     return cell;
 }
 

--- a/JSQMessagesDemo/DemoModelData.h
+++ b/JSQMessagesDemo/DemoModelData.h
@@ -58,4 +58,8 @@ static NSString * const kJSQDemoAvatarIdWoz = @"309-41802-93823";
 
 - (void)addVideoMediaMessage;
 
+- (void)addHTMLMediaMessage;
+
+- (void)addCustomButtonMessage;
+
 @end

--- a/JSQMessagesDemo/DemoModelData.m
+++ b/JSQMessagesDemo/DemoModelData.m
@@ -17,6 +17,9 @@
 //
 
 #import "DemoModelData.h"
+#import "JSQCustomMediaView.h"
+#import "JSQHTMLMessageView.h"
+#import "UIView+JSQMessages.h"
 
 #import "NSUserDefaults+DemoSettings.h"
 
@@ -132,7 +135,9 @@
     
     [self addPhotoMediaMessage];
     [self addAudioMediaMessage];
-    
+    [self addHTMLMediaMessage];
+    [self addCustomButtonMessage];
+
     /**
      *  Setting to load extra messages for testing/demo
      */
@@ -200,6 +205,68 @@
                                                    displayName:kJSQDemoAvatarDisplayNameSquires
                                                          media:videoItem];
     [self.messages addObject:videoMessage];
+}
+
+- (void)addHTMLMediaMessage
+{
+    NSString *htmlString =
+    @"<html><body><div>"
+    @"<p>You can even compose messages using HTML.</p>"
+    @"<p>Sometimes it's <span style=\"text-decoration: line-through\">much</span> <i>easier</i> than attributed text.</p>"
+    @"</div></body></html>";
+
+    JSQHTMLMessageView *htmlView = [[JSQHTMLMessageView alloc] init];
+    [htmlView.webView loadHTMLString:htmlString baseURL:nil];
+
+    [self.messages addObject:[htmlView generateMessageWithSenderId:kJSQDemoAvatarIdSquires displayName:kJSQDemoAvatarDisplayNameSquires]];
+}
+
+- (void)addCustomButtonMessage {
+    JSQCustomMediaView *view = [[JSQCustomMediaView alloc] initWithFrame:CGRectMake(0, 0, 250, 80)];
+
+    UILabel *label = [[UILabel alloc] init];
+    [view addSubview:label];
+
+    label.textAlignment = NSTextAlignmentCenter;
+    label.translatesAutoresizingMaskIntoConstraints = NO;
+
+    [view jsq_pinSubview:label toEdge:NSLayoutAttributeTop];
+    [view jsq_pinSubview:label toEdge:NSLayoutAttributeLeft];
+    [view jsq_pinSubview:label toEdge:NSLayoutAttributeRight];
+
+
+    label.text = @"You rock. Want to be friends?";
+
+    UIButton *button = [UIButton buttonWithType:UIButtonTypeCustom];
+    button.translatesAutoresizingMaskIntoConstraints = NO;
+
+    button.backgroundColor = [UIColor whiteColor];
+    [button setTitle:@"Yes!" forState:UIControlStateNormal];
+    [button setTitleColor:button.tintColor forState:UIControlStateNormal];
+    button.layer.cornerRadius = 3;
+    button.layer.masksToBounds = YES;
+    [view addSubview:button];
+
+    NSLayoutConstraint *xCenterConstraint = [NSLayoutConstraint constraintWithItem:view attribute:NSLayoutAttributeCenterX relatedBy:NSLayoutRelationEqual toItem:button attribute:NSLayoutAttributeCenterX multiplier:1.0 constant:0];
+    [view addConstraint:xCenterConstraint];
+
+    [view addConstraints: [NSLayoutConstraint constraintsWithVisualFormat:@"H:[button(==200)]"
+                                            options: 0
+                                            metrics:nil
+                                              views:@{@"button" : button}]];
+
+    [view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"V:[label(==30)][button(==35)]"
+                                                                 options:0
+                                                                 metrics:nil
+                                                                   views:NSDictionaryOfVariableBindings(label, button)]];
+
+    view.textPropertiesChangedBlock = ^(JSQCustomMediaView *aView) {
+        label.textColor = aView.preferredTextColor;
+        label.font = aView.preferredFont;
+        button.titleLabel.font = aView.preferredFont;
+    };
+
+    [self.messages addObject:[view generateMessageWithSenderId:kJSQDemoAvatarIdCook displayName:kJSQDemoAvatarDisplayNameCook]];
 }
 
 @end

--- a/JSQMessagesTests/ModelTests/JSQCutomMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQCutomMediaItemTests.m
@@ -1,0 +1,50 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  MIT License
+//  Copyright (c) 2014 Jesse Squires
+//  http://opensource.org/licenses/MIT
+//
+
+#import <XCTest/XCTest.h>
+
+#import "JSQCustomMediaItem.h"
+#import "JSQCustomMediaView.h"
+
+@interface JSQCutomMediaItemTests : XCTestCase
+
+@end
+
+@implementation JSQCutomMediaItemTests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testCustomItemInit
+{
+    JSQCustomMediaItem *item = [[JSQCustomMediaItem alloc] initWithView:nil];
+    XCTAssertNotNil(item);
+}
+
+- (void)testMediaDataProtocol
+{
+    JSQCustomMediaItem *item = [[JSQCustomMediaItem alloc] initWithView:nil];
+
+    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySize], CGSizeZero));
+    XCTAssertNil([item mediaView], @"Media view should be nil if view is nil");
+
+    JSQCustomMediaView *view = [[JSQCustomMediaView alloc] initWithFrame:CGRectMake(0, 0, 200, 100)];
+    item.customView = view;
+
+    XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+}
+
+
+@end

--- a/JSQMessagesTests/ViewTests/JSQCustomMediaViewTests.m
+++ b/JSQMessagesTests/ViewTests/JSQCustomMediaViewTests.m
@@ -1,0 +1,38 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  MIT License
+//  Copyright (c) 2014 Jesse Squires
+//  http://opensource.org/licenses/MIT
+//
+
+#import <XCTest/XCTest.h>
+
+#import "JSQCustomMediaView.h"
+
+@interface JSQCustomMediaViewTests : XCTestCase
+
+@end
+
+@implementation JSQCustomMediaViewTests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testCustomMediaViewInit
+{
+    JSQCustomMediaView *view = [[JSQCustomMediaView alloc] initWithFrame:CGRectMake(0, 0, 200, 100)];
+    XCTAssertNotNil(view, @"Custom view should not be nil");
+
+    JSQMessage *message = [view generateMessageWithSenderId:@"1" displayName:@"Foo"];
+    XCTAssertNotNil(message, @"Generated message should not be nil");
+}
+
+@end

--- a/JSQMessagesTests/ViewTests/JSQHTMLMessageViewTests.m
+++ b/JSQMessagesTests/ViewTests/JSQHTMLMessageViewTests.m
@@ -1,0 +1,62 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  MIT License
+//  Copyright (c) 2014 Jesse Squires
+//  http://opensource.org/licenses/MIT
+//
+
+
+#import <XCTest/XCTest.h>
+#import "JSQHTMLMessageView.h"
+
+@interface JSQHTMLMessageViewTests : XCTestCase <JSQCustomMediaViewDelegate>
+@property (nonatomic, strong) XCTestExpectation *fetchExpectation;
+@end
+
+@implementation JSQHTMLMessageViewTests
+
+- (void)setUp {
+    [super setUp];
+}
+
+- (void)tearDown {
+    [super tearDown];
+}
+
+- (void)testHTMLMessageViewInit
+{
+    JSQHTMLMessageView *view = [[JSQHTMLMessageView alloc] initWithFrame:CGRectMake(0, 0, 200, 100)];
+    XCTAssertNotNil(view, @"HTML view should not be nil");
+
+
+    JSQMessage *message = [view generateMessageWithSenderId:@"1" displayName:@"Foo"];
+    XCTAssertNotNil(message, @"Generated message should not be nil");
+}
+
+- (void)testHTMLMessageViewLoad
+{
+    self.fetchExpectation = [self expectationWithDescription:@"Render HTML"];
+
+    JSQHTMLMessageView *view = [[JSQHTMLMessageView alloc] initWithFrame:CGRectMake(0, 0, 200, 100)];
+    XCTAssertNotNil(view, @"HTML view should not be nil");
+
+    view.delegate = self;
+
+    [view.webView loadHTMLString:@"<html><body><div>SOME HTML</div></body></html>" baseURL:nil];
+
+    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError *error) {
+        if (error) {
+            NSLog(@"Timeout Error: %@", error);
+        }
+    }];
+}
+
+- (void)customMediaView:(JSQCustomMediaView *)mediaView contentSizeChanged:(CGSize)newSize {
+    XCTAssertTrue(newSize.height > 0 && newSize.width > 0, @"Rendered content size should not be zero");
+    [self.fetchExpectation fulfill];
+}
+
+@end

--- a/JSQMessagesViewController/Model/JSQCustomMediaItem.h
+++ b/JSQMessagesViewController/Model/JSQCustomMediaItem.h
@@ -1,0 +1,89 @@
+//
+//  Created by Ryan Grimm
+//  ryan@ryangrimm.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import "JSQMediaItem.h"
+#import "JSQCustomMediaView.h"
+@class JSQCustomMediaItem;
+
+/**
+ *  The JSQCustomMediaItemDelegate protocol defines methods that allow the custom media item and it's associated view to
+ *  pass messages back to the messages view controller.
+ */
+@protocol JSQCustomMediaItemDelegate <NSObject>
+
+@required
+
+/**
+ *  Informs the delegate that the custom view reqests a new size for it's collection view cell.
+ *
+ *  @param mediaItem A pointer to this object. Can be useful to find the specific cell that is displayin the media item.
+ *  @param newSize The new size that the view is requesting for it's message bubble.
+ */
+- (void)customMediaItem:(JSQCustomMediaItem *)mediaItem customViewSizeChanged:(CGSize)newSize;
+
+@end
+
+/**
+ *  The `JSQCustomMediaItem` class is a concrete `JSQMediaItem` subclass that implements
+ *  the `JSQMessageMediaData` protocol
+ *  and allows the user to provide a custom view for the message body. An initialized
+ *  `JSQCustomMediaItem` object can be passed
+ *  to a `JSQMediaMessage` object during its initialization to construct a valid media message object.
+ *  You may wish to subclass `JSQCustomMediaItem` to provide additional functionality or behavior
+ *  but doing so is genearlly not needed.
+ */
+@interface JSQCustomMediaItem : JSQMediaItem <JSQMessageMediaData, NSCoding, NSCopying>
+
+/**
+ *  The view to be displayed.
+ */
+@property (nonatomic, strong) JSQCustomMediaView *customView;
+
+/**
+ *  The height of the view when the custom view is nil or when custom view's height is 0
+ *  (defaults to 100 if unchanged).
+ */
+@property (nonatomic) CGFloat preferredDefaultHeight;
+
+/**
+ * The prefered text color that media view's should use.
+ */
+@property (nonatomic, strong) UIColor *preferredTextColor;
+
+/**
+ *  Custom media items can request that their collection view cell size is reevaluated,
+ *  this delegate relays that request.
+ */
+@property (nonatomic, assign) id<JSQCustomMediaItemDelegate> delegate;
+
+/**
+ *  Initializes and returns a custom media item having the given view.
+ *
+ *  @param view   The view to be managed and displayed
+ *
+ *  @return An initialized `JSQCustomMediaView` if successful, `nil` otherwise.
+ *
+ *  @discussion If the view isn't ready to be displayed you may initalize a `JSQCustomMediaView`
+ *  with a `nil` view. Once the view is ready to be displayed set the `customView` property.
+ */
+- (instancetype)initWithView:(JSQCustomMediaView *)view;
+
+
+- (id)init NS_UNAVAILABLE;
+
+@end

--- a/JSQMessagesViewController/Model/JSQCustomMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQCustomMediaItem.m
@@ -1,0 +1,170 @@
+//
+//  Created by Ryan Grimm
+//  ryan@ryangrimm.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import "JSQCustomMediaItem.h"
+
+@interface JSQCustomMediaItem () <JSQCustomMediaViewDelegate>
+- (CGSize)calculateMediaDisplaySizeForView:(JSQCustomMediaView *) view includeLayoutMargins:(BOOL)includeLayoutMargins;
+@end
+
+@implementation JSQCustomMediaItem
+
+#pragma mark - Initialization
+
+- (instancetype)initWithView:(JSQCustomMediaView *)view
+{
+    self = [super init];
+    if (self) {
+        self.preferredDefaultHeight = 100;
+        self.customView = view;
+    }
+    return self;
+}
+
+- (CGSize)calculateMediaDisplaySizeForView:(JSQCustomMediaView *) view includeLayoutMargins:(BOOL)includeLayoutMargins
+{
+    UIEdgeInsets layoutMargins = UIEdgeInsetsZero;
+    CGSize displaySize = CGSizeZero;
+    CGSize viewSize = view.frame.size;
+    if (view == nil || viewSize.height <= 0 || viewSize.width <= 0) {
+        if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+            displaySize = CGSizeMake(355.0f, self.preferredDefaultHeight);
+        }
+        else {
+            displaySize = CGSizeMake(250.0f, self.preferredDefaultHeight);
+        }
+        layoutMargins = [JSQCustomMediaView defaultLayoutMargins];
+    }
+    else {
+        displaySize = view.desiredContentSize;
+        layoutMargins = view.layoutMargins;
+    }
+
+    if (includeLayoutMargins) {
+        displaySize.width = displaySize.width + layoutMargins.left + layoutMargins.right;
+        displaySize.height = displaySize.height + layoutMargins.top + layoutMargins.bottom;
+    }
+
+    return displaySize;
+}
+
+#pragma mark - Setters
+
+- (void)setCustomView:(JSQCustomMediaView *)customView
+{
+    if (customView != nil) {
+        _customView = customView;
+
+        CGSize defaultSize = [self calculateMediaDisplaySizeForView:customView includeLayoutMargins:NO];
+        customView.frame = CGRectMake(0, 0, defaultSize.width, defaultSize.height);
+        customView.delegate = self;
+    }
+    else {
+        _customView.delegate = nil;
+    }
+}
+
+- (void)customMediaView:(JSQCustomMediaView *)mediaView contentSizeChanged:(CGSize)newSize
+{
+    CGRect frame = self.customView.frame;
+    frame.size = newSize;
+    self.customView.frame = frame;
+
+    newSize.width = newSize.width + mediaView.layoutMargins.left + mediaView.layoutMargins.right;
+    newSize.height = newSize.height + mediaView.layoutMargins.top + mediaView.layoutMargins.bottom;
+
+    if ([self.delegate respondsToSelector:@selector(customMediaItem:customViewSizeChanged:)]) {
+        [self.delegate customMediaItem:self customViewSizeChanged:newSize];
+    }
+}
+
+- (void)setPreferredTextColor:(UIColor *)preferredTextColor
+{
+    self.customView.preferredTextColor = preferredTextColor;
+}
+
+- (UIColor *)preferredTextColor
+{
+    return self.customView.preferredTextColor;
+}
+
+#pragma mark - JSQMessageMediaData protocol
+
+- (JSQCustomMediaView *)mediaView
+{
+    return self.customView;
+}
+
+- (NSUInteger)mediaHash
+{
+    return self.customView.hash;
+}
+
+- (CGSize)mediaViewDisplaySize
+{
+    return [self calculateMediaDisplaySizeForView:self.customView includeLayoutMargins:YES];
+}
+
+
+#pragma mark - NSObject
+
+- (NSUInteger)hash
+{
+    return self.customView.hash;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"<%@: customView=%@, appliesMediaViewMaskAsOutgoing=%@>",
+            [self class], self.customView, @(self.appliesMediaViewMaskAsOutgoing)];
+}
+
+#pragma mark - NSCoding
+
+- (instancetype)initWithCoder:(NSCoder *)aDecoder
+{
+    self = [super initWithCoder:aDecoder];
+    if (self) {
+        self.preferredDefaultHeight = [aDecoder decodeFloatForKey:NSStringFromSelector(@selector(preferredDefaultHeight))];
+        self.customView = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(customView))];
+        self.preferredTextColor = [aDecoder decodeObjectForKey:NSStringFromSelector(@selector(preferredTextColor))];
+    }
+    return self;
+}
+
+- (void)encodeWithCoder:(NSCoder *)aCoder
+{
+    [super encodeWithCoder:aCoder];
+    [aCoder encodeObject:self.customView forKey:NSStringFromSelector(@selector(customView))];
+    [aCoder encodeFloat:self.preferredDefaultHeight forKey:NSStringFromSelector(@selector(preferredDefaultHeight))];
+    [aCoder encodeObject:self.preferredTextColor forKey:NSStringFromSelector(@selector(preferredTextColor))];
+
+}
+
+#pragma mark - NSCopying
+
+- (instancetype)copyWithZone:(NSZone *)zone
+{
+    JSQCustomMediaItem *copy = [[[self class] allocWithZone:zone] initWithView:self.customView];
+    copy.delegate = self.delegate;
+    copy.preferredDefaultHeight = self.preferredDefaultHeight;
+    copy.preferredTextColor = self.preferredTextColor;
+    return copy;
+}
+
+@end

--- a/JSQMessagesViewController/Views/JSQCustomMediaView.h
+++ b/JSQMessagesViewController/Views/JSQCustomMediaView.h
@@ -1,0 +1,117 @@
+//
+//  Created by Ryan Grimm
+//  ryan@ryangrimm.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+#import <UIKit/UIKit.h>
+@class JSQCustomMediaView;
+@class JSQMessage;
+
+typedef void (^JSQCustomMediaViewTextPropertiesChangedBlock)(JSQCustomMediaView *view);
+
+/**
+ *  The JSQCustomMediaViewDelegate protocol defines methods that allow the custom view to
+ *  pass messages back to its custom media item.
+ */
+@protocol JSQCustomMediaViewDelegate <NSObject>
+
+@required
+
+/**
+ *  Informs the delegate that the custom view reqests a new size for it's collection view cell.
+ *
+ *  @param mediaView A pointer to this object.
+ *  @param newSize The new size that the view is requesting for it's content.
+ */
+- (void)customMediaView:(JSQCustomMediaView *)mediaView contentSizeChanged:(CGSize)newSize;
+
+@end
+
+/**
+ *  The JSQCustomMediaView class is a subclass of UIView and it (or a subclass of it) must be used to create a `JSQCustomMediaItem`.
+ * 
+ *  @discussion It is highly reccomended to use autolayout to position the subviews inside of the custom media view!
+ *
+ *  @see JSQHTMLMessageView for an example subclass.
+ */
+@interface JSQCustomMediaView : UIView
+
+/**
+ *  The default values to use for the layout margins. If a subclass needs different layout margins, this is
+ *  the place to override and set those.
+ */
++ (UIEdgeInsets)defaultLayoutMargins;
+
+/**
+ *  Set to true if a message bubble be included around the custom view. Default is true.
+ */
+@property (nonatomic) BOOL includeMessageBubble;
+
+/**
+ *  Holds the perferred font that text in the message bubble should use. Custom views should use this property
+ *  to obtain the font for text in their views.
+ */
+@property (nonatomic, strong) UIFont *preferredFont;
+
+/**
+ *  Holds the preferred color that text inthe message bubble should use. Custom views should use this property to
+ *  obtain the color for text in their views.
+ */
+@property (nonatomic, strong) UIColor *preferredTextColor;
+
+/**
+ *  A hash value used to reference stored cell information. If a stable hash value can be caluclated for your view,
+ *  subclass and provide it. The default value is a random number.
+ */
+@property (nonatomic, readonly) NSUInteger hash;
+
+/**
+ *  The size that the view desires for it's content.
+ */
+@property (nonatomic, readonly) CGSize desiredContentSize;
+
+/**
+ *  Custom views can reqeust that their cell size is reevaluated, this delegate relays that request.
+ */
+@property (nonatomic, assign) id<JSQCustomMediaViewDelegate> delegate;
+
+/**
+ *  This block is called whenever the text properties (preferredFont or preferredTextColor) change. If not sublcassing
+ *  this is critical in order to get the correct values of these properties as they are not usually available immediatly
+ *  immediatly after initalization.
+ */
+@property (nonatomic, copy) JSQCustomMediaViewTextPropertiesChangedBlock textPropertiesChangedBlock;
+
+/**
+ *  This is a shortcut for generating a JSQMessage object. Optionally you can create the `JSQCustomMediaItem` and `JSQMessage`
+ *  objects yourself but that is almost never needed.
+ * 
+ *  @param senderId The id of the sender
+ *  @param displayName The display name of the sender
+ */
+- (JSQMessage *)generateMessageWithSenderId:(NSString *)senderId displayName:(NSString *)displayName;
+
+/**
+ *  This is a shortcut for generating a JSQMessage object. Optionally you can create the `JSQCustomMediaItem` and `JSQMessage`
+ *  objects yourself but that is almost never needed.
+ *
+ *  @param senderId The id of the sender
+ *  @param displayName The display name of the sender
+ *  @param date The date of the message
+ */
+- (JSQMessage *)generateMessageWithSenderId:(NSString *)senderId displayName:(NSString *)displayName date:(NSDate *)date;
+
+@end

--- a/JSQMessagesViewController/Views/JSQCustomMediaView.m
+++ b/JSQMessagesViewController/Views/JSQCustomMediaView.m
@@ -1,0 +1,111 @@
+//
+//  Created by Ryan Grimm
+//  ryan@ryangrimm.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+
+#import "JSQCustomMediaView.h"
+#import "JSQCustomMediaItem.h"
+#import "JSQMessage.h"
+
+@implementation JSQCustomMediaView
+
++ (UIEdgeInsets)defaultLayoutMargins {
+    return UIEdgeInsetsMake(0, 10, 0, 5);
+}
+
+- (instancetype)init {
+    self = [super init];
+    if (self != nil)
+    {
+        CGRect rect = CGRectZero;
+        rect.size = [self desiredContentSize];
+        self.frame = rect;
+        [self commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if(self != nil)
+    {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)aCoder
+{
+    self = [super initWithCoder:aCoder];
+    if(self != nil)
+    {
+        [self commonInit];
+    }
+    return self;
+}
+
+- (void)commonInit
+{
+    self.layoutMargins = [JSQCustomMediaView defaultLayoutMargins];
+    self.includeMessageBubble = YES;
+    _preferredFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
+}
+
+- (void)setPreferredFont:(UIFont *)preferredFont {
+    _preferredFont = preferredFont;
+    if (self.textPropertiesChangedBlock) {
+        self.textPropertiesChangedBlock(self);
+    }
+}
+
+- (void)setPreferredTextColor:(UIColor *)preferredTextColor {
+    _preferredTextColor = preferredTextColor;
+    if (self.textPropertiesChangedBlock) {
+        self.textPropertiesChangedBlock(self);
+    }
+}
+
+- (NSUInteger)hash
+{
+    return arc4random();
+}
+
+- (CGSize)desiredContentSize
+{
+    if (CGRectEqualToRect(self.frame, CGRectZero)) {
+        if ([UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad) {
+            return CGSizeMake(355.0f, 100);
+        }
+
+        return CGSizeMake(250.0f, 100);
+    }
+
+    return self.frame.size;
+}
+
+- (JSQMessage *)generateMessageWithSenderId:(NSString *)senderId displayName:(NSString *)displayName
+{
+    JSQCustomMediaItem *customItem = [[JSQCustomMediaItem alloc] initWithView:self];
+    return [JSQMessage messageWithSenderId:senderId displayName:displayName media:customItem];
+}
+
+- (JSQMessage *)generateMessageWithSenderId:(NSString *)senderId displayName:(NSString *)displayName date:(NSDate *)date
+{
+    JSQCustomMediaItem *customItem = [[JSQCustomMediaItem alloc] initWithView:self];
+    return [[JSQMessage alloc] initWithSenderId:senderId senderDisplayName:displayName date:date media:customItem];
+}
+
+@end

--- a/JSQMessagesViewController/Views/JSQHTMLMessageView.h
+++ b/JSQMessagesViewController/Views/JSQHTMLMessageView.h
@@ -1,0 +1,75 @@
+//
+//  Created by Ryan Grimm
+//  ryan@ryangrimm.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+
+#import "JSQCustomMediaView.h"
+
+@class JSQHTMLMessageView;
+@class JSQMessage;
+
+
+/**
+ *  The JSQHTMLMessageViewDelegate is pretty much just a wrapper around the UIWebView delegate. The UIWebView
+ *  delegate is used internally and therefore the webView.delegate property should not be set. Use the webDelegate
+ *  property instead in order to access these methods.
+ */
+@protocol JSQHTMLMessageViewDelegate <NSObject>
+
+@optional
+
+/**
+ *  See the UIWebViewDelegate for details.
+ */
+- (BOOL)messageView:(JSQHTMLMessageView *)view shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType;
+
+/**
+ *  See the UIWebViewDelegate for details.
+ */
+- (void)messageViewDidStartLoad:(JSQHTMLMessageView *)view;
+
+/**
+ *  See the UIWebViewDelegate for details.
+ */
+- (void)messageViewDidFinishLoad:(JSQHTMLMessageView *)view;
+
+/**
+ *  See the UIWebViewDelegate for details.
+ */
+- (void)messageView:(JSQHTMLMessageView *)view didFailLoadWithError:(NSError *)error;
+
+@end
+
+/**
+ *  Allows HTML to be included inside a message bubble. The web view does not (and should not) allow for user interactions. Therefore, links and other
+ *  user actions are not enabled. If complex layouts and user interactions are required, look towards a subclass of `JSQCustomMediaView`.
+ *  
+ *  To load HTML in the view, call one of the UIWebView load methods on the `webView` property
+ *  (loadData:MIMEType:textEncodingName:baseURL:, loadHTMLString:baseURL:, or loadRequest).
+ */
+@interface JSQHTMLMessageView : JSQCustomMediaView
+
+/**
+ *
+ *  @discussion Do not set the delegate on the webView! If you need access to the webView delegate, set the webDelegate property.
+ */
+@property (nonatomic, readonly) UIWebView *webView;
+
+/**
+ *  Set this delegate to gain access to the UIWebView delegate callbacks.
+ */
+@property (nonatomic, assign) id<JSQHTMLMessageViewDelegate> webDelegate;
+
+@end

--- a/JSQMessagesViewController/Views/JSQHTMLMessageView.m
+++ b/JSQMessagesViewController/Views/JSQHTMLMessageView.m
@@ -1,0 +1,140 @@
+//
+//  Created by Ryan Grimm
+//  ryan@ryangrimm.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+
+#import "JSQHTMLMessageView.h"
+
+
+@interface JSQHTMLMessageView () <UIWebViewDelegate>
+@end
+
+@implementation JSQHTMLMessageView
+
+@synthesize webView = _webView;
+
+- (UIWebView *)webView {
+    if (_webView != nil) {
+        return _webView;
+    }
+
+    _webView = [[UIWebView alloc] initWithFrame:self.bounds];
+    _webView.delegate = self;
+    _webView.contentMode = UIViewContentModeScaleAspectFill;
+    _webView.clipsToBounds = YES;
+    _webView.userInteractionEnabled = NO;
+    _webView.scrollView.scrollEnabled = NO;
+    _webView.backgroundColor = [UIColor clearColor];
+    _webView.opaque = NO;
+
+    [self addSubview:_webView];
+    return _webView;
+}
+
+- (void)willMoveToSuperview:(UIView *)newSuperview {
+    [super willMoveToSuperview:newSuperview];
+
+    _webView.translatesAutoresizingMaskIntoConstraints = NO;
+
+    NSArray *constraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|-[_webView]-|" options:0 metrics:nil views:NSDictionaryOfVariableBindings(_webView)];
+    [self addConstraints:constraints];
+
+    constraints = [NSLayoutConstraint constraintsWithVisualFormat:@"V:|-[_webView]-|" options:0 metrics:nil views:NSDictionaryOfVariableBindings(_webView)];
+    [self addConstraints:constraints];
+}
+
+- (CGSize)desiredContentSize {
+    if (self.webView == nil || CGSizeEqualToSize(self.webView.frame.size, CGSizeZero)) {
+        return [super desiredContentSize];
+    }
+    CGSize size = self.webView.scrollView.contentSize;
+    return CGSizeMake(size.width, size.height);
+}
+
+- (void)setPreferredTextColor:(UIColor *)preferredTextColor {
+    [super setPreferredTextColor:preferredTextColor];
+    [self changeTextColor];
+}
+
+- (void)changeFont {
+
+    NSString *script = [NSString stringWithFormat:@"document.body.style.fontFamily = \"-apple-system\""];
+    [self.webView stringByEvaluatingJavaScriptFromString:script];
+}
+
+- (void)changeTextColor {
+    if (self.webView == nil || self.preferredTextColor == nil) {
+        return;
+    }
+
+    NSString *htmlColor = nil;
+
+    CGFloat red, green, blue, alpha;
+    if([self.preferredTextColor getRed:&red green:&green blue:&blue alpha:&alpha]) {
+        htmlColor = [NSString stringWithFormat:@"rgb(%i, %i, %i)", (int)red * 255, (int)green * 255, (int)blue * 255];
+    }
+    else {
+        CGFloat white;
+        [self.preferredTextColor getWhite:&white alpha:&alpha];
+        htmlColor = [NSString stringWithFormat:@"rgb(%i, %i, %i)", (int)white * 255, (int)white * 255, (int)white * 255];
+    }
+
+    NSString *script = [NSString stringWithFormat:@"document.body.style.color = \"%@\"; document.body.style.opacity = %f;", htmlColor, alpha];
+    [self.webView stringByEvaluatingJavaScriptFromString:script];
+}
+
+
+#pragma mark - UIWebViewDelegate Methods
+- (BOOL)webView:(UIWebView *)webView shouldStartLoadWithRequest:(NSURLRequest *)request navigationType:(UIWebViewNavigationType)navigationType
+{
+    if ([self.webDelegate respondsToSelector:@selector(messageView:shouldStartLoadWithRequest:navigationType:)]) {
+        return [self.webDelegate messageView:self shouldStartLoadWithRequest:request navigationType:navigationType];
+    }
+    return YES;
+}
+
+- (void)webViewDidStartLoad:(UIWebView *)webView {
+    if ([self.webDelegate respondsToSelector:@selector(messageViewDidStartLoad:)]) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [self.webDelegate messageViewDidStartLoad:self];
+        });
+    }
+}
+
+- (void)webViewDidFinishLoad:(UIWebView *)webView
+{
+    [self changeFont];
+    [self changeTextColor];
+
+    if ([self.delegate respondsToSelector:@selector(customMediaView:contentSizeChanged:)]) {
+        [self.delegate customMediaView:self contentSizeChanged:self.webView.scrollView.contentSize];
+    }
+
+    if ([self.webDelegate respondsToSelector:@selector(messageViewDidFinishLoad:)]) {
+        [self.webDelegate messageViewDidFinishLoad:self];
+    }
+
+}
+
+- (void)webView:(UIWebView *)webView didFailLoadWithError:(NSError *)error
+{
+    if ([self.webDelegate respondsToSelector:@selector(messageView:didFailLoadWithError:)]) {
+        [self.webDelegate messageView:self didFailLoadWithError:error];
+    }
+}
+
+
+
+@end

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -24,6 +24,7 @@
 
 #import "UIView+JSQMessages.h"
 #import "UIDevice+JSQMessages.h"
+#import "JSQCustomMediaView.h"
 
 
 static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
@@ -309,7 +310,11 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 
 - (void)setMediaView:(UIView *)mediaView
 {
-    [self.messageBubbleImageView removeFromSuperview];
+    BOOL includeMessageBubble = [mediaView isKindOfClass:[JSQCustomMediaView class]] && ((JSQCustomMediaView *)mediaView).includeMessageBubble;
+
+    // Hiding the bubble image view since it may need to be included the next time the cell is reused
+    self.messageBubbleImageView.hidden = !includeMessageBubble;
+
     [self.textView removeFromSuperview];
 
     [mediaView setTranslatesAutoresizingMaskIntoConstraints:NO];
@@ -324,8 +329,15 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     //  thus, remove any additional subviews hidden behind the new media view
     dispatch_async(dispatch_get_main_queue(), ^{
         for (NSUInteger i = 0; i < self.messageBubbleContainerView.subviews.count; i++) {
-            if (self.messageBubbleContainerView.subviews[i] != _mediaView) {
-                [self.messageBubbleContainerView.subviews[i] removeFromSuperview];
+            UIView *subview = self.messageBubbleContainerView.subviews[i];
+            if (subview.hidden) {
+                continue;
+            }
+            if (includeMessageBubble && subview != _mediaView && subview != self.messageBubbleImageView) {
+                [subview removeFromSuperview];
+            }
+            else if (includeMessageBubble == NO && subview != _mediaView) {
+                [subview removeFromSuperview];
             }
         }
     });


### PR DESCRIPTION
## Pull request checklist
- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: **:muscle::sunglasses::facepunch:**
#### This fixes issue #1536.
## What's in this pull request?

The JSQCustomMediaItem class is the starting place for allowing users to
create their own custom views. It manages the communication between the
cell/collection view and the custom view.

The JSQCustomMediaView is the foundation for all custom views. Any
custom view either needs to use an instance of this class and add their
own viewes to it or subclass it.

The JSQHTMLMessageView is a subclass of JSQCustomMediaView and allows
HTML to be displayed inside a message bubble. As a nice bonus, the default font and text color for the HTML is fully managed for the user.

Basic unit tests as well as enhancements to the demo are included.

![simulator screen shot apr 10 2016 1 45 37 pm](https://cloud.githubusercontent.com/assets/221752/14412996/95c7be44-ff22-11e5-9af0-7cc9e9e83fad.png)
