### PR TITLE
Add avatar imageView and typing indicator text to TypingIndicatorFooterView

### DIFF
--- a/JSQMessagesDemo/Base.lproj/Main.storyboard
+++ b/JSQMessagesDemo/Base.lproj/Main.storyboard
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9060" systemVersion="15B42" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="JRd-Be-psV">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="JRd-Be-psV">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9051"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
     </dependencies>
     <scenes>
         <!--Root View Controller-->
@@ -12,28 +12,24 @@
                     <tableView key="view" opaque="NO" clipsSubviews="YES" clearsContextBeforeDrawing="NO" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="d0b-Sx-5kJ">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell contentMode="scaleToFill" selectionStyle="blue" accessoryType="disclosureIndicator" hidesAccessoryWhenEditing="NO" indentationLevel="1" indentationWidth="0.0" reuseIdentifier="CellIdentifier" textLabel="2qz-Z2-GmT" style="IBUITableViewCellStyleDefault" id="k8B-cw-dMU">
                                 <rect key="frame" x="0.0" y="114" width="320" height="44"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="k8B-cw-dMU" id="kX4-QF-oKx">
-                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="287" height="43.5"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="left" text="Title" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" id="2qz-Z2-GmT">
-                                            <rect key="frame" x="15" y="0.0" width="270" height="43"/>
+                                            <rect key="frame" x="15" y="0.0" width="270" height="43.5"/>
                                             <autoresizingMask key="autoresizingMask"/>
-                                            <animations/>
                                             <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                             <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                     </subviews>
-                                    <animations/>
                                 </tableViewCellContentView>
-                                <animations/>
                             </tableViewCell>
                         </prototypes>
                     </tableView>
@@ -55,7 +51,6 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="grouped" separatorStyle="default" allowsSelection="NO" rowHeight="44" sectionHeaderHeight="10" sectionFooterHeight="10" id="GY5-ob-knb">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <animations/>
                         <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
                         <sections>
                             <tableViewSection headerTitle="Messages" id="ygb-Dp-o4r">
@@ -64,12 +59,11 @@
                                         <rect key="frame" x="0.0" y="114" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Eii-ro-1yZ" id="qU9-o3-MWC">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="K7N-os-fuc">
                                                     <rect key="frame" x="263" y="6" width="51" height="31"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="A6s-Sr-u8U"/>
                                                         <constraint firstAttribute="height" constant="31" id="z9i-uJ-MBq"/>
@@ -80,13 +74,11 @@
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Load extra messages" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bSS-CD-nfD">
                                                     <rect key="frame" x="8" y="10" width="247" height="24"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="bSS-CD-nfD" firstAttribute="top" secondItem="qU9-o3-MWC" secondAttribute="top" constant="10" id="4Iw-W0-qZs"/>
                                                 <constraint firstAttribute="trailing" secondItem="K7N-os-fuc" secondAttribute="trailing" constant="8" id="Fex-nr-C1R"/>
@@ -96,18 +88,16 @@
                                                 <constraint firstAttribute="bottom" secondItem="bSS-CD-nfD" secondAttribute="bottom" constant="9" id="poL-wE-Eir"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="bZI-G1-eYA">
                                         <rect key="frame" x="0.0" y="158" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="bZI-G1-eYA" id="1Ho-Zz-KN0">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hMq-Ee-EJK">
                                                     <rect key="frame" x="263" y="6" width="51" height="31"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="31" id="gM4-dK-cl7"/>
                                                         <constraint firstAttribute="width" constant="49" id="hvu-Yy-NTG"/>
@@ -118,13 +108,11 @@
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Load really long message" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="YV3-GH-Yul">
                                                     <rect key="frame" x="8" y="10" width="247" height="24"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="hMq-Ee-EJK" secondAttribute="centerY" id="CcO-KD-31y"/>
                                                 <constraint firstItem="hMq-Ee-EJK" firstAttribute="leading" secondItem="YV3-GH-Yul" secondAttribute="trailing" constant="8" id="KFO-nO-4r4"/>
@@ -134,18 +122,16 @@
                                                 <constraint firstItem="YV3-GH-Yul" firstAttribute="leading" secondItem="1Ho-Zz-KN0" secondAttribute="leading" constant="8" id="xyR-oc-iUp"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="2Th-gL-oAN">
                                         <rect key="frame" x="0.0" y="202" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="2Th-gL-oAN" id="OFq-Mz-mbl">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="baL-Tb-bTJ">
                                                     <rect key="frame" x="263" y="6" width="51" height="31"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="SaV-RG-DVL"/>
                                                         <constraint firstAttribute="height" constant="31" id="dXb-pb-etA"/>
@@ -156,13 +142,11 @@
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Empty view, no messages" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="DoU-SU-Nek">
                                                     <rect key="frame" x="8" y="10" width="247" height="24"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="DoU-SU-Nek" firstAttribute="leading" secondItem="OFq-Mz-mbl" secondAttribute="leading" constant="8" id="A9k-hI-0BH"/>
                                                 <constraint firstItem="DoU-SU-Nek" firstAttribute="top" secondItem="OFq-Mz-mbl" secondAttribute="top" constant="10" id="Uji-LE-8IA"/>
@@ -172,22 +156,20 @@
                                                 <constraint firstAttribute="centerY" secondItem="baL-Tb-bTJ" secondAttribute="centerY" id="hx4-cn-W0h"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Avatars" id="ns0-OO-PGu">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="hYS-4f-iL6">
-                                        <rect key="frame" x="0.0" y="289" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="288" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="hYS-4f-iL6" id="dk1-tc-gux">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fLZ-NC-aPO">
                                                     <rect key="frame" x="263" y="6" width="51" height="31"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="width" constant="49" id="1lf-6y-hgz"/>
                                                         <constraint firstAttribute="height" constant="31" id="rdQ-ol-d20"/>
@@ -198,13 +180,11 @@
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Incoming avatars" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RUq-Pa-3nx">
                                                     <rect key="frame" x="8" y="10" width="247" height="24"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="fLZ-NC-aPO" secondAttribute="centerY" id="17e-cC-bP4"/>
                                                 <constraint firstAttribute="bottom" secondItem="RUq-Pa-3nx" secondAttribute="bottom" constant="9" id="7Yt-uN-sOS"/>
@@ -214,18 +194,16 @@
                                                 <constraint firstItem="RUq-Pa-3nx" firstAttribute="leading" secondItem="dk1-tc-gux" secondAttribute="leading" constant="8" id="mhd-oX-p53"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="VF7-uo-6Pc">
-                                        <rect key="frame" x="0.0" y="333" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="332" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="VF7-uo-6Pc" id="zad-JQ-TRI">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LuM-mk-Zj6">
                                                     <rect key="frame" x="263" y="6" width="51" height="31"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="31" id="QXv-ty-g0B"/>
                                                         <constraint firstAttribute="width" constant="49" id="rZ3-cO-f8t"/>
@@ -236,13 +214,11 @@
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Outgoing avatars" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9Rr-S8-Uae">
                                                     <rect key="frame" x="8" y="10" width="247" height="24"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstAttribute="centerY" secondItem="LuM-mk-Zj6" secondAttribute="centerY" id="2oC-JM-LVI"/>
                                                 <constraint firstAttribute="bottom" secondItem="9Rr-S8-Uae" secondAttribute="bottom" constant="9" id="5xp-ez-tac"/>
@@ -252,22 +228,20 @@
                                                 <constraint firstItem="9Rr-S8-Uae" firstAttribute="top" secondItem="zad-JQ-TRI" secondAttribute="top" constant="10" id="Yiv-t6-Xj5"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
                             <tableViewSection headerTitle="Dynamic Behaviors" footerTitle="NOTE: This feature is experimental" id="o5m-OT-1Iw">
                                 <cells>
                                     <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="q07-lZ-YdI">
-                                        <rect key="frame" x="0.0" y="420" width="320" height="44"/>
+                                        <rect key="frame" x="0.0" y="418" width="320" height="44"/>
                                         <autoresizingMask key="autoresizingMask"/>
                                         <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="q07-lZ-YdI" id="btE-Mk-fSE">
-                                            <rect key="frame" x="0.0" y="0.0" width="320" height="43"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" on="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uXC-2j-cgi">
                                                     <rect key="frame" x="263" y="6" width="51" height="31"/>
-                                                    <animations/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="31" id="5bI-xQ-njj"/>
                                                         <constraint firstAttribute="width" constant="49" id="PG2-X2-FdD"/>
@@ -278,13 +252,11 @@
                                                 </switch>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Springy bubbles" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3d2-fZ-dx9">
                                                     <rect key="frame" x="8" y="10" width="247" height="24"/>
-                                                    <animations/>
                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                     <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                             </subviews>
-                                            <animations/>
                                             <constraints>
                                                 <constraint firstItem="3d2-fZ-dx9" firstAttribute="leading" secondItem="btE-Mk-fSE" secondAttribute="leading" constant="8" id="6Cs-6l-Xzp"/>
                                                 <constraint firstItem="uXC-2j-cgi" firstAttribute="leading" secondItem="3d2-fZ-dx9" secondAttribute="trailing" constant="8" id="7Mq-HR-4nY"/>
@@ -294,7 +266,44 @@
                                                 <constraint firstAttribute="trailing" secondItem="uXC-2j-cgi" secondAttribute="trailing" constant="8" id="zzu-aP-ZiL"/>
                                             </constraints>
                                         </tableViewCellContentView>
-                                        <animations/>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                            <tableViewSection headerTitle="Typing Indicator" id="P03-Bj-ZgX">
+                                <cells>
+                                    <tableViewCell contentMode="scaleToFill" selectionStyle="default" indentationWidth="10" id="qY8-BT-1Pd">
+                                        <rect key="frame" x="0.0" y="528" width="320" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="qY8-BT-1Pd" id="qfd-BE-xs1">
+                                            <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <switch opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="750" verticalHuggingPriority="750" contentHorizontalAlignment="center" contentVerticalAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="oLL-u1-nyT">
+                                                    <rect key="frame" x="263" y="6" width="51" height="31"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" constant="49" id="JH9-gk-nIy"/>
+                                                        <constraint firstAttribute="height" constant="31" id="U1o-SN-2Un"/>
+                                                    </constraints>
+                                                    <connections>
+                                                        <action selector="didTapSwitch:" destination="y7K-ZU-Xs9" eventType="valueChanged" id="LFP-zP-a5F"/>
+                                                    </connections>
+                                                </switch>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Avatar + text indicator style" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hAd-Cm-lJB">
+                                                    <rect key="frame" x="8" y="10" width="247" height="24"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="hAd-Cm-lJB" firstAttribute="leading" secondItem="qfd-BE-xs1" secondAttribute="leading" constant="8" id="28T-j4-4P7"/>
+                                                <constraint firstAttribute="bottom" secondItem="hAd-Cm-lJB" secondAttribute="bottom" constant="9" id="7Ym-w0-Njf"/>
+                                                <constraint firstItem="hAd-Cm-lJB" firstAttribute="top" secondItem="qfd-BE-xs1" secondAttribute="top" constant="10" id="Zhd-cJ-JaZ"/>
+                                                <constraint firstAttribute="centerY" secondItem="oLL-u1-nyT" secondAttribute="centerY" id="oFd-xh-G2F"/>
+                                                <constraint firstAttribute="trailing" secondItem="oLL-u1-nyT" secondAttribute="trailing" constant="8" id="rD3-rC-TLp"/>
+                                                <constraint firstItem="oLL-u1-nyT" firstAttribute="leading" secondItem="hAd-Cm-lJB" secondAttribute="trailing" constant="8" id="xXY-cu-ZpE"/>
+                                            </constraints>
+                                        </tableViewCellContentView>
                                     </tableViewCell>
                                 </cells>
                             </tableViewSection>
@@ -312,6 +321,7 @@
                         <outlet property="longMessageSwitch" destination="hMq-Ee-EJK" id="Vs2-fX-Hys"/>
                         <outlet property="outgoingAvatarsSwitch" destination="LuM-mk-Zj6" id="EAh-35-xjI"/>
                         <outlet property="springySwitch" destination="uXC-2j-cgi" id="Jzx-1y-VZP"/>
+                        <outlet property="typingIndicatorShowAvatarSwitch" destination="oLL-u1-nyT" id="4GY-BQ-vVa"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="5u5-k6-W2j" userLabel="First Responder" sceneMemberID="firstResponder"/>
@@ -324,7 +334,6 @@
                 <navigationController definesPresentationContext="YES" id="s4z-xn-r6C" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="G3q-Gy-0Lf">
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <connections>
                         <segue destination="2Qx-iu-03V" kind="relationship" relationship="rootViewController" id="cuu-7c-yOr"/>
@@ -345,7 +354,6 @@
                     <view key="view" contentMode="scaleToFill" id="Vop-TB-ImV">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <navigationItem key="navigationItem" id="URv-4c-d6h"/>
@@ -360,7 +368,6 @@
                 <navigationController definesPresentationContext="YES" id="JRd-Be-psV" sceneMemberID="viewController">
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="YZb-OI-WKd">
                         <autoresizingMask key="autoresizingMask"/>
-                        <animations/>
                     </navigationBar>
                     <connections>
                         <segue destination="rXs-qR-ns2" kind="relationship" relationship="rootViewController" id="8xe-QC-QaY"/>
@@ -381,7 +388,6 @@
                     <view key="view" contentMode="scaleToFill" id="SsE-pA-zOd">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                        <animations/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
                     </view>
                     <navigationItem key="navigationItem" id="gBw-Dh-o4F"/>

--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -62,6 +62,11 @@
         self.collectionView.collectionViewLayout.outgoingAvatarViewSize = CGSizeZero;
     }
     
+    if ([NSUserDefaults typingIndicatorStyleSettingIsAvatar]) {
+        self.collectionView.typingIndicatorAvatarImage = [UIImage imageNamed:@"demo_avatar_cook"];
+        self.collectionView.typingIndicatorMessage = @"Steve is typing…";
+    }
+    
     self.showLoadEarlierMessagesHeader = YES;
     
     self.navigationItem.rightBarButtonItem = [[UIBarButtonItem alloc] initWithImage:[UIImage jsq_defaultTypingIndicatorImage]
@@ -547,8 +552,6 @@
     
     return cell;
 }
-
-
 
 #pragma mark - UICollectionView Delegate
 

--- a/JSQMessagesDemo/DemoSettingsViewController.h
+++ b/JSQMessagesDemo/DemoSettingsViewController.h
@@ -39,4 +39,6 @@
 
 @property (weak, nonatomic) IBOutlet UISwitch *springySwitch;
 
+@property (weak, nonatomic) IBOutlet UISwitch *typingIndicatorShowAvatarSwitch;
+
 @end

--- a/JSQMessagesDemo/DemoSettingsViewController.m
+++ b/JSQMessagesDemo/DemoSettingsViewController.m
@@ -41,13 +41,14 @@
     self.outgoingAvatarsSwitch.on = [NSUserDefaults outgoingAvatarSetting];
     
     self.springySwitch.on = [NSUserDefaults springinessSetting];
+    
+    self.typingIndicatorShowAvatarSwitch.on = [NSUserDefaults typingIndicatorStyleSettingIsAvatar];
 }
 
 - (IBAction)didTapSwitch:(UISwitch *)sender
 {
     if (sender == self.extraMessagesSwitch) {
         [NSUserDefaults saveExtraMessagesSetting:sender.on];
-        
     }
     else if (sender == self.longMessageSwitch) {
         [NSUserDefaults saveLongMessageSetting:sender.on];
@@ -63,6 +64,9 @@
     }
     else if (sender == self.springySwitch) {
         [NSUserDefaults saveSpringinessSetting:sender.on];
+    }
+    else if (sender == self.typingIndicatorShowAvatarSwitch) {
+        [NSUserDefaults saveTypingIndicatorStyleSettingAsAvatar:sender.on];
     }
     
     [[NSUserDefaults standardUserDefaults] synchronize];

--- a/JSQMessagesDemo/NSUserDefaults+DemoSettings.h
+++ b/JSQMessagesDemo/NSUserDefaults+DemoSettings.h
@@ -38,4 +38,7 @@
 + (void)saveIncomingAvatarSetting:(BOOL)value;
 + (BOOL)incomingAvatarSetting;
 
++ (void)saveTypingIndicatorStyleSettingAsAvatar:(BOOL)value;
++ (BOOL)typingIndicatorStyleSettingIsAvatar;
+
 @end

--- a/JSQMessagesDemo/NSUserDefaults+DemoSettings.m
+++ b/JSQMessagesDemo/NSUserDefaults+DemoSettings.m
@@ -24,6 +24,7 @@ static NSString * const kSettingEmptyMessages = @"kSettingEmptyMessages";
 static NSString * const kSettingSpringiness = @"kSettingSpringiness";
 static NSString * const kSettingIncomingAvatar = @"kSettingIncomingAvatar";
 static NSString * const kSettingOutgoingAvatar = @"kSettingOutgoingAvatar";
+static NSString * const kSettingTypingIndicatorStyleIsAvatar = @"kSettingTypingIndicatorStyleIsAvatar";
 
 
 @implementation NSUserDefaults (DemoSettings)
@@ -86,6 +87,16 @@ static NSString * const kSettingOutgoingAvatar = @"kSettingOutgoingAvatar";
 + (BOOL)incomingAvatarSetting
 {
     return [[NSUserDefaults standardUserDefaults] boolForKey:kSettingIncomingAvatar];
+}
+
++ (void)saveTypingIndicatorStyleSettingAsAvatar:(BOOL)value
+{
+     [[NSUserDefaults standardUserDefaults] setBool:value forKey:kSettingTypingIndicatorStyleIsAvatar];
+}
+
++ (BOOL)typingIndicatorStyleSettingIsAvatar
+{
+    return [[NSUserDefaults standardUserDefaults] boolForKey:kSettingTypingIndicatorStyleIsAvatar];
 }
 
 @end

--- a/JSQMessagesTests/ViewTests/JSQMessagesTypingIndicatorFooterViewTests.m
+++ b/JSQMessagesTests/ViewTests/JSQMessagesTypingIndicatorFooterViewTests.m
@@ -12,8 +12,26 @@
 
 #import "JSQMessagesTypingIndicatorFooterView.h"
 
+@interface JSQMessagesTypingIndicatorFooterView (Testable)
 
-@interface JSQMessagesTypingIndicatorFooterViewTests : XCTestCase
+@property (weak, nonatomic) IBOutlet UIImageView *bubbleImageView;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *bubbleImageViewRightHorizontalConstraint;
+
+@property (weak, nonatomic) IBOutlet UIImageView *typingIndicatorImageView;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *typingIndicatorImageViewRightHorizontalConstraint;
+
+@property (weak, nonatomic) IBOutlet UIImageView *avatarImageView;
+@property (weak, nonatomic) IBOutlet UILabel *typingIndicatorLabel;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *avatarImageViewWidthConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *avatarImageViewToTypingIndicatorLabelHorizontalConstraint;
+
+@end
+
+
+@interface JSQMessagesTypingIndicatorFooterViewTests : XCTestCase {
+    UINib *footerViewNib;
+    JSQMessagesTypingIndicatorFooterView *footerView;
+}
 @end
 
 
@@ -22,6 +40,8 @@
 - (void)setUp
 {
     [super setUp];
+    footerViewNib = [JSQMessagesTypingIndicatorFooterView nib];
+    footerView = [footerViewNib instantiateWithOwner:nil options:nil].firstObject;
 }
 
 - (void)tearDown
@@ -31,11 +51,62 @@
 
 - (void)testTypingIndicatorFooterViewInit
 {
-    UINib *footerView = [JSQMessagesTypingIndicatorFooterView nib];
-    XCTAssertNotNil(footerView, @"Nib should not be nil");
+    XCTAssertNotNil(footerViewNib, @"Nib should not be nil");
     
     NSString *footerId = [JSQMessagesTypingIndicatorFooterView footerReuseIdentifier];
     XCTAssertNotNil(footerId, @"Footer view identifier should not be nil");
+}
+
+- (void)testNibInstantiatesCorrectClass
+{
+    XCTAssertTrue([footerView isMemberOfClass:[JSQMessagesTypingIndicatorFooterView class]]);
+}
+
+- (void)testEllipsisImageNilIfConfiguredWithAvatarImage
+{
+    XCTAssertTrue(footerView.typingIndicatorImageView.image == nil);
+}
+
+- (void)testBubbleImageNilIfConfiguredWithAvatarImage
+{
+    [footerView configureWithAvatarImage:[UIImage new] message:nil textColor:nil font:nil];
+    XCTAssertTrue(footerView.bubbleImageView.image == nil);
+}
+
+- (void)testTypingIndicatorLabelHiddenByDefault
+{
+    XCTAssertTrue(footerView.typingIndicatorLabel.hidden == YES);
+}
+
+- (void)testTypingIndicatorLabelNotHiddenIfConfiguredWithAvatarImage
+{
+    [footerView configureWithAvatarImage:[UIImage new] message:nil textColor:nil font:nil];
+    XCTAssertTrue(footerView.typingIndicatorLabel.hidden == NO);
+}
+
+- (void)testConfigureWithMessageSetsLabelText
+{
+    [footerView configureWithAvatarImage:nil message:@"Test message" textColor:nil font:nil];
+    XCTAssertEqualObjects(@"Test message", footerView.typingIndicatorLabel.text);
+}
+
+- (void)testSetsLabelTextColor
+{
+    [footerView configureWithAvatarImage:nil message:nil textColor:[UIColor greenColor] font:nil];
+    XCTAssertEqualObjects([UIColor greenColor], footerView.typingIndicatorLabel.textColor);
+}
+
+- (void)testConfigureWithNilMessageDoesNotNilLabelText
+{
+    [footerView configureWithAvatarImage:[UIImage new] message:nil textColor:nil font:nil];
+    XCTAssertNotNil(footerView.typingIndicatorLabel.text);
+}
+
+- (void)testConfigureWithNilImageSetsImageViewWidthToZero
+{
+    [footerView configureWithAvatarImage:nil message:@"Test message" textColor:nil font:nil];
+    [footerView layoutIfNeeded];
+    XCTAssertEqual(0, footerView.avatarImageView.bounds.size.width);
 }
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.h
@@ -73,6 +73,26 @@
 @property (strong, nonatomic) UIColor *typingIndicatorEllipsisColor;
 
 /**
+ *  The image to be used as an avatar on a user's typing indicator. If not set, no avatar image will be shown. Setting this image will hide the typing indicator message bubble and ellipsis image.
+ */
+@property (strong, nonatomic) UIImage *typingIndicatorAvatarImage;
+
+/**
+ *  The string to indicate that a user is typing. If not set, a generic message will be shown. Setting this string will hide the typing indicator message bubble and ellipsis image.
+ */
+@property (copy, nonatomic) NSString *typingIndicatorMessage;
+
+/**
+ *  The text color to use in displaying the string stored in `typingIndicatorMessage`. The default value is a light gray color. Setting this value will hide the typing indicator message bubble and ellipsis image.
+ */
+@property (strong, nonatomic) UIColor *typingIndicatorTextColor;
+
+/**
+ *  The font to use in displaying the string stored in `typingIndicatorMessage`. The default value is an italic system font at 11pt. Setting this value will hide the typing indicator message bubble and ellipsis image.
+ */
+@property (strong, nonatomic) UIFont *typingIndicatorTextFont;
+
+/**
  *  The color of the text in the load earlier messages header. The default value is a bright blue color.
  */
 @property (strong, nonatomic) UIColor *loadEarlierMessagesHeaderTextColor;

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
@@ -102,10 +102,21 @@
                                                                                  withReuseIdentifier:[JSQMessagesTypingIndicatorFooterView footerReuseIdentifier]
                                                                                         forIndexPath:indexPath];
 
-    [footerView configureWithEllipsisColor:self.typingIndicatorEllipsisColor
-                        messageBubbleColor:self.typingIndicatorMessageBubbleColor
-                       shouldDisplayOnLeft:self.typingIndicatorDisplaysOnLeft
-                         forCollectionView:self];
+    if (self.typingIndicatorAvatarImage || self.typingIndicatorMessage || self.typingIndicatorTextColor || self.typingIndicatorTextFont) {
+
+        [footerView configureWithAvatarImage:self.typingIndicatorAvatarImage
+                                     message:self.typingIndicatorMessage
+                                   textColor:self.typingIndicatorTextColor
+                                        font:self.typingIndicatorTextFont];
+        
+    } else {
+        
+        [footerView configureWithEllipsisColor:self.typingIndicatorEllipsisColor
+                            messageBubbleColor:self.typingIndicatorMessageBubbleColor
+                           shouldDisplayOnLeft:self.typingIndicatorDisplaysOnLeft
+                             forCollectionView:self];
+    }
+    
 
     return footerView;
 }

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.h
@@ -64,4 +64,17 @@ FOUNDATION_EXPORT const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight;
                shouldDisplayOnLeft:(BOOL)shouldDisplayOnLeft
                  forCollectionView:(UICollectionView *)collectionView;
 
+/**
+ *  Configures the receiver with the specified attributes for the given collection view.
+ *  Call this method after dequeuing the footer view.
+ *
+ *  @param avatarImage       The avatar image to display in the typing indicator. Setting this value to `nil` hides the avatar image view.
+ *  @param textColor         The color of the typing indicator text. This value defaults to `UIColor.lightGrayColor()`.
+ *  @param font              The font used to display the typing indicator test. This value defaults to `UIFont.italicSystemFontOfSize(11)`.
+ */
+- (void)configureWithAvatarImage:(UIImage *)avatarImage
+                         message:(NSString *)message
+                       textColor:(UIColor *)textColor
+                            font:(UIFont *)font;
+
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.m
@@ -23,7 +23,7 @@
 #import "UIImage+JSQMessages.h"
 
 const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
-
+const CGFloat kJSQMessagesTypingIndicatorBubbleMarginMinimumSpacing = 6.0f;
 
 @interface JSQMessagesTypingIndicatorFooterView ()
 
@@ -32,6 +32,12 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
 
 @property (weak, nonatomic) IBOutlet UIImageView *typingIndicatorImageView;
 @property (weak, nonatomic) IBOutlet NSLayoutConstraint *typingIndicatorImageViewRightHorizontalConstraint;
+
+@property (weak, nonatomic) IBOutlet UIImageView *avatarImageView;
+@property (weak, nonatomic) IBOutlet UILabel *typingIndicatorLabel;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *avatarImageViewWidthConstraint;
+@property (weak, nonatomic) IBOutlet NSLayoutConstraint *avatarImageViewToTypingIndicatorLabelHorizontalConstraint;
+
 
 @end
 
@@ -81,8 +87,7 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
     NSParameterAssert(ellipsisColor != nil);
     NSParameterAssert(messageBubbleColor != nil);
     NSParameterAssert(collectionView != nil);
-    
-    CGFloat bubbleMarginMinimumSpacing = 6.0f;
+
     CGFloat indicatorMarginMinimumSpacing = 26.0f;
     
     JSQMessagesBubbleImageFactory *bubbleImageFactory = [[JSQMessagesBubbleImageFactory alloc] init];
@@ -94,7 +99,7 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
         CGFloat bubbleWidth = CGRectGetWidth(self.bubbleImageView.frame);
         CGFloat indicatorWidth = CGRectGetWidth(self.typingIndicatorImageView.frame);
         
-        CGFloat bubbleMarginMaximumSpacing = collectionViewWidth - bubbleWidth - bubbleMarginMinimumSpacing;
+        CGFloat bubbleMarginMaximumSpacing = collectionViewWidth - bubbleWidth - kJSQMessagesTypingIndicatorBubbleMarginMinimumSpacing;
         CGFloat indicatorMarginMaximumSpacing = collectionViewWidth - indicatorWidth - indicatorMarginMinimumSpacing;
         
         self.bubbleImageViewRightHorizontalConstraint.constant = bubbleMarginMaximumSpacing;
@@ -103,13 +108,43 @@ const CGFloat kJSQMessagesTypingIndicatorFooterViewHeight = 46.0f;
     else {
         self.bubbleImageView.image = [bubbleImageFactory outgoingMessagesBubbleImageWithColor:messageBubbleColor].messageBubbleImage;
         
-        self.bubbleImageViewRightHorizontalConstraint.constant = bubbleMarginMinimumSpacing;
+        self.bubbleImageViewRightHorizontalConstraint.constant = kJSQMessagesTypingIndicatorBubbleMarginMinimumSpacing;
         self.typingIndicatorImageViewRightHorizontalConstraint.constant = indicatorMarginMinimumSpacing;
     }
     
     [self setNeedsUpdateConstraints];
     
     self.typingIndicatorImageView.image = [[UIImage jsq_defaultTypingIndicatorImage] jsq_imageMaskedWithColor:ellipsisColor];
+}
+
+- (void)configureWithAvatarImage:(UIImage *)avatarImage
+                         message:(NSString *)message
+                       textColor:(UIColor *)textColor
+                            font:(UIFont *)font;
+{
+    NSParameterAssert(avatarImage || message || textColor || font);
+    
+    self.typingIndicatorLabel.hidden = NO;
+    
+    if (avatarImage) {
+        self.avatarImageView.image = avatarImage;
+        self.avatarImageView.layer.cornerRadius = self.avatarImageView.layer.bounds.size.width / 2;
+    } else {
+        self.avatarImageViewWidthConstraint.constant = 0;
+        self.avatarImageViewToTypingIndicatorLabelHorizontalConstraint.constant = 0;
+    }
+    if (message) {
+        self.typingIndicatorLabel.text = message;
+    }
+    if (textColor) {
+        self.typingIndicatorLabel.textColor = textColor;
+    }
+    if (font) {
+        self.typingIndicatorLabel.font = font;
+    }
+    
+    self.typingIndicatorImageView.image = nil;
+    self.bubbleImageView.image = nil;
 }
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.xib
+++ b/JSQMessagesViewController/Views/JSQMessagesTypingIndicatorFooterView.xib
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="9531" systemVersion="15C50" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15E65" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -25,18 +26,39 @@
                         <constraint firstAttribute="height" constant="34" id="j0C-FV-2gV"/>
                     </constraints>
                 </imageView>
+                <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="cgQ-al-ksn" userLabel="Avatar Image View">
+                    <rect key="frame" x="6" y="20" width="20" height="20"/>
+                    <constraints>
+                        <constraint firstAttribute="width" secondItem="cgQ-al-ksn" secondAttribute="height" multiplier="1:1" id="XzC-Xd-wyc"/>
+                        <constraint firstAttribute="width" constant="20" id="t0b-rs-iux"/>
+                    </constraints>
+                </imageView>
+                <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="typing…" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hQ6-hL-x5B">
+                    <rect key="frame" x="31" y="23" width="46" height="14"/>
+                    <fontDescription key="fontDescription" type="italicSystem" pointSize="12"/>
+                    <color key="textColor" white="0.66666666666666663" alpha="1" colorSpace="calibratedWhite"/>
+                    <nil key="highlightedColor"/>
+                </label>
             </subviews>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="Vwf-dy-PS6" secondAttribute="trailing" constant="260" id="1Tm-qD-wIK"/>
                 <constraint firstAttribute="bottom" secondItem="Z1D-Tr-HPK" secondAttribute="bottom" constant="6" id="EVf-Sx-8mX"/>
                 <constraint firstAttribute="bottom" secondItem="Vwf-dy-PS6" secondAttribute="bottom" constant="6" id="Hik-Wl-aK2"/>
+                <constraint firstAttribute="bottom" secondItem="cgQ-al-ksn" secondAttribute="bottom" constant="6" id="KUs-CX-Muj"/>
+                <constraint firstItem="hQ6-hL-x5B" firstAttribute="leading" secondItem="cgQ-al-ksn" secondAttribute="trailing" constant="5" id="Lcx-6l-UMz"/>
                 <constraint firstAttribute="trailing" secondItem="Z1D-Tr-HPK" secondAttribute="trailing" constant="246" id="YMl-ej-UZl"/>
+                <constraint firstItem="hQ6-hL-x5B" firstAttribute="centerY" secondItem="cgQ-al-ksn" secondAttribute="centerY" id="lEB-Yt-L66"/>
+                <constraint firstItem="cgQ-al-ksn" firstAttribute="leading" secondItem="ajJ-uk-b04" secondAttribute="leading" constant="6" id="qMt-5s-aKq"/>
             </constraints>
             <connections>
+                <outlet property="avatarImageView" destination="cgQ-al-ksn" id="RSk-9a-w8z"/>
+                <outlet property="avatarImageViewToTypingIndicatorLabelHorizontalConstraint" destination="Lcx-6l-UMz" id="5Gw-A2-72p"/>
+                <outlet property="avatarImageViewWidthConstraint" destination="t0b-rs-iux" id="S6U-Tf-BRm"/>
                 <outlet property="bubbleImageView" destination="Z1D-Tr-HPK" id="WpE-rP-oYB"/>
                 <outlet property="bubbleImageViewRightHorizontalConstraint" destination="YMl-ej-UZl" id="Thu-7D-dhU"/>
                 <outlet property="typingIndicatorImageView" destination="Vwf-dy-PS6" id="wQA-Pe-rx6"/>
                 <outlet property="typingIndicatorImageViewRightHorizontalConstraint" destination="1Tm-qD-wIK" id="FUp-oC-c0I"/>
+                <outlet property="typingIndicatorLabel" destination="hQ6-hL-x5B" id="KFw-HQ-lt7"/>
             </connections>
         </collectionReusableView>
     </objects>


### PR DESCRIPTION
## Pull request checklist
- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: CW
#### This fixes issue #606.
## What's in this pull request?

> Add avatar imageView and typing indicator text to TypingIndicatorFooterView nib. Configure with image to show avatar image. Configure with string, color or font to specify typing indicator message. Default config works as previous. Unit tests included at no extra cost!

![simulator screen shot 16 apr 2016 10 52 23](https://cloud.githubusercontent.com/assets/510679/14580305/5202052c-03c1-11e6-9e5c-06b940e629f5.png)
