### PR TITLE
Extend delegate methods for JSQMediaItem

### DIFF
--- a/JSQMessages.xcodeproj/project.pbxproj
+++ b/JSQMessages.xcodeproj/project.pbxproj
@@ -108,6 +108,7 @@
 		88C00A501A44D4D800B004B3 /* JSQPhotoMediaItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C00A4F1A44D4D800B004B3 /* JSQPhotoMediaItemTests.m */; };
 		88C00A521A44D4E500B004B3 /* JSQVideoMediaItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C00A511A44D4E500B004B3 /* JSQVideoMediaItemTests.m */; };
 		88C4583019F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m in Sources */ = {isa = PBXBuildFile; fileRef = 88C4582F19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m */; };
+		BB0D292D1CDF98C200511CD9 /* JSQMediaItemTests.m in Sources */ = {isa = PBXBuildFile; fileRef = BB0D292C1CDF98C100511CD9 /* JSQMediaItemTests.m */; };
 		BF6DA766BD3B8893A67FB2BD /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3F882AA48978C11F64DC2DF /* libPods.a */; };
 		C8994EF7DDBE74B9E3F1A16C /* libPods-JSQMessagesTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = E23238C8D8DF79244DEE1787 /* libPods-JSQMessagesTests.a */; };
 		E8877F1947CE8050ECCD9539 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = C3F882AA48978C11F64DC2DF /* libPods.a */; };
@@ -279,6 +280,7 @@
 		88C4582E19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSQMessagesMediaViewBubbleImageMasker.h; sourceTree = "<group>"; };
 		88C4582F19F5F7A0008FD427 /* JSQMessagesMediaViewBubbleImageMasker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMessagesMediaViewBubbleImageMasker.m; sourceTree = "<group>"; };
 		AD6E75315517DE46FE495B65 /* Pods.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.release.xcconfig; path = "Pods/Target Support Files/Pods/Pods.release.xcconfig"; sourceTree = "<group>"; };
+		BB0D292C1CDF98C100511CD9 /* JSQMediaItemTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JSQMediaItemTests.m; sourceTree = "<group>"; };
 		C3F882AA48978C11F64DC2DF /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		E23238C8D8DF79244DEE1787 /* libPods-JSQMessagesTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-JSQMessagesTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
@@ -512,6 +514,10 @@
 				88445B3F19E1B4470014F889 /* JSQLocationMediaItem.m */,
 				88A901B419F618B100F99777 /* JSQMediaItem.h */,
 				88A901B519F618B100F99777 /* JSQMediaItem.m */,
+				88A25F8519D8E01A00924534 /* JSQPhotoMediaItem.h */,
+				88A25F8619D8E01A00924534 /* JSQPhotoMediaItem.m */,
+				886C33FB19F4371E006B4997 /* JSQVideoMediaItem.h */,
+				886C33FC19F4371E006B4997 /* JSQVideoMediaItem.m */,
 				88A25F7919D8E01A00924534 /* JSQMessage.h */,
 				88A25F7A19D8E01A00924534 /* JSQMessage.m */,
 				88A25F7B19D8E01A00924534 /* JSQMessageAvatarImageDataSource.h */,
@@ -524,10 +530,6 @@
 				88A25F8219D8E01A00924534 /* JSQMessagesBubbleImage.m */,
 				88A25F8319D8E01A00924534 /* JSQMessagesCollectionViewDataSource.h */,
 				88A25F8419D8E01A00924534 /* JSQMessagesCollectionViewDelegateFlowLayout.h */,
-				88A25F8519D8E01A00924534 /* JSQPhotoMediaItem.h */,
-				88A25F8619D8E01A00924534 /* JSQPhotoMediaItem.m */,
-				886C33FB19F4371E006B4997 /* JSQVideoMediaItem.h */,
-				886C33FC19F4371E006B4997 /* JSQVideoMediaItem.m */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -615,12 +617,13 @@
 			children = (
 				54271E3F1C905D1600294290 /* JSQAudioMediaItemTests.m */,
 				88C00A4D1A44D4C600B004B3 /* JSQLocationMediaItemTests.m */,
+				88C00A4F1A44D4D800B004B3 /* JSQPhotoMediaItemTests.m */,
+				BB0D292C1CDF98C100511CD9 /* JSQMediaItemTests.m */,
+				88C00A511A44D4E500B004B3 /* JSQVideoMediaItemTests.m */,
 				88A25FF319D8E18400924534 /* JSQMessageMediaTests.m */,
 				88A25FF419D8E18400924534 /* JSQMessagesAvatarImageTests.m */,
 				88A25FF519D8E18400924534 /* JSQMessagesBubbleImageTests.m */,
 				88A25FF619D8E18400924534 /* JSQMessageTextTests.m */,
-				88C00A4F1A44D4D800B004B3 /* JSQPhotoMediaItemTests.m */,
-				88C00A511A44D4E500B004B3 /* JSQVideoMediaItemTests.m */,
 			);
 			path = ModelTests;
 			sourceTree = "<group>";
@@ -927,6 +930,7 @@
 				88A2600D19D8E18400924534 /* JSQMessageMediaTests.m in Sources */,
 				88A2600719D8E18400924534 /* JSQMessagesAvatarImageFactoryTests.m in Sources */,
 				88A2600419D8E18400924534 /* JSQMessagesUIViewTests.m in Sources */,
+				BB0D292D1CDF98C200511CD9 /* JSQMediaItemTests.m in Sources */,
 				88A2600F19D8E18400924534 /* JSQMessagesBubbleImageTests.m in Sources */,
 				88A2600E19D8E18400924534 /* JSQMessagesAvatarImageTests.m in Sources */,
 				88A2600919D8E18400924534 /* JSQMessagesTimestampFormatterTests.m in Sources */,

--- a/JSQMessagesTests/ModelTests/JSQAudioMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQAudioMediaItemTests.m
@@ -11,6 +11,10 @@
 #import <XCTest/XCTest.h>
 
 #import "JSQAudioMediaItem.h"
+#import "JSQMessage.h"
+#import "JSQMessagesCollectionView.h"
+#import "JSQAudioMediaViewAttributes.h"
+#import "UIImage+JSQMessages.h"
 
 @interface JSQAudioMediaItemTests : XCTestCase
 
@@ -32,6 +36,9 @@
 {
     JSQAudioMediaItem *item = [[JSQAudioMediaItem alloc] initWithData:[NSData data]];
     XCTAssertNotNil(item);
+    
+    JSQAudioMediaItem *item2 = [[JSQAudioMediaItem alloc] initWithAudioViewAttributes:[[JSQAudioMediaViewAttributes alloc] init]];
+    XCTAssertNotNil(item2);
 }
 
 - (void)testAudioItemIsEqual
@@ -46,6 +53,44 @@
     XCTAssertEqual([item hash], [copy hash], @"Copied item hashes should be equal");
     
     XCTAssertEqualObjects(item, item, @"Item should be equal to itself");
+    
+    copy.appliesMediaViewMaskAsOutgoing = NO;
+    XCTAssertNotEqualObjects(item, copy);
+    
+    copy.appliesMediaViewMaskAsOutgoing = YES;
+    copy.audioData = nil;
+    XCTAssertNotEqualObjects(item, copy);
+}
+
+- (void)testAudioAttributesSet {
+    JSQAudioMediaViewAttributes *attr = [[JSQAudioMediaViewAttributes alloc] init];
+    
+    attr.playButtonImage = [UIImage jsq_defaultPlayImage];
+    XCTAssertNotNil(attr.playButtonImage);
+    
+    attr.pauseButtonImage = [UIImage jsq_defaultPauseImage];
+    XCTAssertNotNil(attr.pauseButtonImage);
+    
+    attr.labelFont = [UIFont systemFontOfSize:12];
+    XCTAssertEqualObjects(attr.labelFont, [UIFont systemFontOfSize:12]);
+    
+    attr.showFractionalSeconds = YES;
+    XCTAssertTrue(attr.showFractionalSeconds);
+    
+    attr.backgroundColor = [UIColor blackColor];
+    XCTAssertEqualObjects(attr.backgroundColor, [UIColor blackColor]);
+    
+    attr.tintColor = [UIColor blackColor];
+    XCTAssertEqualObjects(attr.tintColor, [UIColor blackColor]);
+    
+    attr.controlInsets = UIEdgeInsetsMake(6, 6, 6, 18);
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(attr.controlInsets, UIEdgeInsetsMake(6, 6, 6, 18)));
+    
+    attr.controlPadding = 6;
+    XCTAssertTrue(attr.controlPadding == 6);
+    
+    attr.audioCategory = @"AVAudioSessionCategoryPlayback";
+    XCTAssertEqualObjects(attr.audioCategory, @"AVAudioSessionCategoryPlayback");
 }
 
 - (void)testAudioItemArchiving
@@ -64,14 +109,34 @@
 {
     JSQAudioMediaItem *item = [[JSQAudioMediaItem alloc] init];
     
-    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySize], CGSizeZero));
-    XCTAssertNotNil([item mediaPlaceholderView]);
-    XCTAssertNil([item mediaView], @"Media view should be nil if image is nil");
+    NSString *senderId = @"324543-43556-212343";
+    NSString *senderDisplayName = @"Jesse Squires";
+    NSDate *date = [NSDate date];
+    JSQMessage *message = [[JSQMessage alloc] initWithSenderId:senderId senderDisplayName:senderDisplayName date:date media:item];
+    JSQMessagesCollectionViewFlowLayout *layout = [[JSQMessagesCollectionViewFlowLayout alloc] init];
+    JSQMessagesCollectionView *collectionView = [[JSQMessagesCollectionView alloc] initWithFrame:CGRectMake(0, 0, 500, 500) collectionViewLayout:layout];
+    
+    XCTAssertNotNil(collectionView.collectionViewLayout);
+    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySizeWithMessageData:message layout:layout], CGSizeZero));
+    XCTAssertNotNil([item mediaPlaceholderViewWithMessageData:message layout:layout]);
+    XCTAssertNil([item mediaViewWithMessageData:message layout:layout], @"Media view should be nil if image is nil");
 
-    NSString * sample = [[NSBundle mainBundle] pathForResource:@"jsq_messages_sample" ofType:@"m4a"];
+    NSString *sample = [[NSBundle mainBundle] pathForResource:@"jsq_messages_sample" ofType:@"m4a"];
     item.audioData = [NSData dataWithContentsOfFile:sample];
     
-    XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+    XCTAssertNotNil([item mediaViewWithMessageData:message layout:layout], @"Media view should NOT be nil once item has media data");
+    
+    NSURL *sampleURL = [[NSBundle mainBundle] URLForResource:@"jsq_messages_sample" withExtension:@"m4a"];
+    [item setAudioDataWithUrl:sampleURL];
+    
+    XCTAssertNotNil([item mediaViewWithMessageData:message layout:layout], @"Media view should NOT be nil once item has media data");
+}
+
+- (void)testAudioItemDescription
+{
+    JSQAudioMediaItem *item = [[JSQAudioMediaItem alloc] init];
+    XCTAssertTrue([item.description containsString:@"audioData"]);
+    XCTAssertTrue([item.description containsString:@"appliesMediaViewMaskAsOutgoing"]);
 }
 
 @end

--- a/JSQMessagesTests/ModelTests/JSQLocationMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQLocationMediaItemTests.m
@@ -11,7 +11,8 @@
 #import <XCTest/XCTest.h>
 
 #import "JSQLocationMediaItem.h"
-
+#import "JSQMessage.h"
+#import "JSQMessagesCollectionView.h"
 
 @interface JSQLocationMediaItemTests : XCTestCase
 
@@ -40,13 +41,68 @@
     XCTAssertNotNil(item);
 }
 
-- (void)testMediaDataProtocol
+- (void)testSetProperties
 {
     JSQLocationMediaItem *item = [[JSQLocationMediaItem alloc] init];
     
-    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySize], CGSizeZero));
-    XCTAssertNotNil([item mediaPlaceholderView]);
-    XCTAssertNil([item mediaView], @"Media view should be nil if location is nil");
+    item.location = self.location;
+    XCTAssertNotNil(item.location);
+    XCTAssertTrue(CLLocationCoordinate2DIsValid(item.coordinate));
+    
+    item.location = nil;
+    XCTAssertNil(item.location);
+    
+    item.appliesMediaViewMaskAsOutgoing = YES;
+    XCTAssertTrue(item.appliesMediaViewMaskAsOutgoing);
+}
+
+- (void)testLocationItemIsEqual
+{
+    JSQLocationMediaItem *item = [[JSQLocationMediaItem alloc] initWithLocation:self.location];
+    
+    JSQLocationMediaItem *copy = [item copy];
+    
+    XCTAssertEqualObjects(item, copy, @"Copied items should be equal");
+    
+    XCTAssertEqual([item hash], [copy hash], @"Copied item hashes should be equal");
+    XCTAssertEqual([item mediaHash], [copy mediaHash], @"Copied item media hashes should be equal");
+    
+    XCTAssertEqualObjects(item, item, @"Item should be equal to itself");
+    
+    copy.appliesMediaViewMaskAsOutgoing = NO;
+    XCTAssertNotEqualObjects(item, copy);
+    
+    copy.appliesMediaViewMaskAsOutgoing = NO;
+    XCTAssertNotEqualObjects(item, copy);
+}
+
+- (void)testLocationItemArchiving
+{
+    JSQLocationMediaItem *item = [[JSQLocationMediaItem alloc] initWithLocation:self.location];
+    
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:item];
+    
+    JSQLocationMediaItem *unarchivedItem = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    
+    XCTAssertEqualObjects(item, unarchivedItem);
+}
+
+- (void)testMediaDataProtocol
+{
+    JSQLocationMediaItem *item = [[JSQLocationMediaItem alloc] init];
+    item.location = nil;
+    
+    NSString *senderId = @"324543-43556-212343";
+    NSString *senderDisplayName = @"Jesse Squires";
+    NSDate *date = [NSDate date];
+    JSQMessage *message = [[JSQMessage alloc] initWithSenderId:senderId senderDisplayName:senderDisplayName date:date media:item];
+    JSQMessagesCollectionViewFlowLayout *layout = [[JSQMessagesCollectionViewFlowLayout alloc] init];
+    JSQMessagesCollectionView *collectionView = [[JSQMessagesCollectionView alloc] initWithFrame:CGRectMake(0, 0, 500, 500) collectionViewLayout:layout];
+    
+    XCTAssertNotNil(collectionView.collectionViewLayout);
+    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySizeWithMessageData:message layout:layout], CGSizeZero));
+    XCTAssertNotNil([item mediaPlaceholderViewWithMessageData:message layout:layout]);
+    XCTAssertNil([item mediaViewWithMessageData:message layout:layout], @"Media view should be nil if location is nil");
     
     XCTestExpectation *expectation = [self expectationWithDescription:[NSString stringWithFormat:@"%s", __PRETTY_FUNCTION__]];
     
@@ -58,7 +114,14 @@
         XCTAssertNil(error, @"Expectation should not error");
     }];
     
-    XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+    XCTAssertNotNil([item mediaViewWithMessageData:message layout:layout], @"Media view should NOT be nil once item has media data");
+}
+
+- (void)testLocationItemDescription
+{
+    JSQLocationMediaItem *item = [[JSQLocationMediaItem alloc] initWithLocation:self.location];
+    XCTAssertTrue([item.description containsString:@"location"]);
+    XCTAssertTrue([item.description containsString:@"appliesMediaViewMaskAsOutgoing"]);
 }
 
 @end

--- a/JSQMessagesTests/ModelTests/JSQMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQMediaItemTests.m
@@ -1,0 +1,105 @@
+//
+//  JSQMediaItemTests.m
+//  JSQMessages
+//
+//  Created by Alex Gurin on 5/8/16.
+//  Copyright © 2016 Hexed Bits. All rights reserved.
+//
+
+#import <XCTest/XCTest.h>
+
+#import "JSQMediaItem.h"
+#import "JSQMessage.h"
+#import "JSQMessagesCollectionView.h"
+
+@interface JSQMediaItemTests : XCTestCase
+
+@end
+
+@implementation JSQMediaItemTests
+
+- (void)setUp
+{
+    [super setUp];
+}
+
+- (void)tearDown
+{
+    [super tearDown];
+}
+
+- (void)testPhotoItemInit
+{
+    JSQMediaItem *item = [[JSQMediaItem alloc] init];
+    XCTAssertNotNil(item);
+}
+
+- (void)testPhotoItemIsEqual
+{
+    JSQMediaItem *item = [[JSQMediaItem alloc] init];
+    
+    JSQMediaItem *copy = [item copy];
+    
+    XCTAssertEqualObjects(item, copy, @"Copied items should be equal");
+    
+    XCTAssertTrue([item isEqual:item]);
+    
+    XCTAssertNotEqualObjects(item, [NSString new]);
+    
+    XCTAssertEqual([item hash], [copy hash], @"Copied item hashes should be equal");
+    XCTAssertEqual([item mediaHash], [copy mediaHash], @"Copied item media hashes should be equal");
+    
+    XCTAssertEqualObjects(item, item, @"Item should be equal to itself");
+}
+
+- (void)testPhotoItemArchiving
+{
+    JSQMediaItem *item = [[JSQMediaItem alloc] init];
+    
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:item];
+    
+    JSQMediaItem *unarchivedItem = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    
+    XCTAssertEqualObjects(item, unarchivedItem);
+}
+
+- (void)testMediaDataProtocol
+{
+    JSQMediaItem *item = [[JSQMediaItem alloc] init];
+    
+    NSString *senderId = @"324543-43556-212343";
+    NSString *senderDisplayName = @"Jesse Squires";
+    NSDate *date = [NSDate date];
+    JSQMessage *message = [[JSQMessage alloc] initWithSenderId:senderId senderDisplayName:senderDisplayName date:date media:item];
+    JSQMessagesCollectionViewFlowLayout *layout = [[JSQMessagesCollectionViewFlowLayout alloc] init];
+    JSQMessagesCollectionView *collectionView = [[JSQMessagesCollectionView alloc] initWithFrame:CGRectMake(0, 0, 500, 500) collectionViewLayout:layout];
+    
+    XCTAssertNotNil(collectionView.collectionViewLayout);
+    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySizeWithMessageData:message layout:layout], CGSizeZero));
+    XCTAssertNotNil([item mediaPlaceholderViewWithMessageData:message layout:layout]);
+}
+
+- (void)testPhotoItemDescription
+{
+    JSQMediaItem *item = [[JSQMediaItem alloc] init];
+    XCTAssertTrue([item.description containsString:@"appliesMediaViewMaskAsOutgoing"]);
+}
+
+- (void)testDidReceiveMemoryWarning
+{
+    JSQMediaItem *item = [[JSQMediaItem alloc] init];
+    
+    NSString *senderId = @"324543-43556-212343";
+    NSString *senderDisplayName = @"Jesse Squires";
+    NSDate *date = [NSDate date];
+    JSQMessage *message = [[JSQMessage alloc] initWithSenderId:senderId senderDisplayName:senderDisplayName date:date media:item];
+    JSQMessagesCollectionViewFlowLayout *layout = [[JSQMessagesCollectionViewFlowLayout alloc] init];
+    JSQMessagesCollectionView *collectionView = [[JSQMessagesCollectionView alloc] initWithFrame:CGRectMake(0, 0, 500, 500) collectionViewLayout:layout];
+    
+    XCTAssertNotNil(collectionView.collectionViewLayout);
+    XCTAssertNotNil([item mediaPlaceholderViewWithMessageData:message layout:layout]);
+    [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidReceiveMemoryWarningNotification object:nil];
+    XCTAssertNil(item.cachedPlaceholderView);
+}
+
+@end

--- a/JSQMessagesTests/ModelTests/JSQMessageMediaTests.m
+++ b/JSQMessagesTests/ModelTests/JSQMessageMediaTests.m
@@ -21,9 +21,20 @@
 
 @implementation FakeMedia
 
-- (UIView *)mediaView { return [UIView new]; }
-- (UIView *)mediaPlaceholderView { return [self mediaView]; }
-- (CGSize)mediaViewDisplaySize { return CGSizeMake(50, 50); }
+- (UIView *)mediaViewWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout
+{
+    return [UIView new];
+}
+
+- (UIView *)mediaPlaceholderViewWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout
+{
+    return [self mediaViewWithMessageData:messageData layout:layout];
+}
+
+- (CGSize)mediaViewDisplaySizeWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout
+{
+    return CGSizeMake(50, 50);
+}
 
 - (void)encodeWithCoder:(NSCoder *)aCoder { }
 - (id)initWithCoder:(NSCoder *)aDecoder { return [self init]; }

--- a/JSQMessagesTests/ModelTests/JSQPhotoMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQPhotoMediaItemTests.m
@@ -11,7 +11,8 @@
 #import <XCTest/XCTest.h>
 
 #import "JSQPhotoMediaItem.h"
-
+#import "JSQMessage.h"
+#import "JSQMessagesCollectionView.h"
 
 @interface JSQPhotoMediaItemTests : XCTestCase
 
@@ -64,13 +65,28 @@
 {
     JSQPhotoMediaItem *item = [[JSQPhotoMediaItem alloc] initWithImage:nil];
     
-    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySize], CGSizeZero));
-    XCTAssertNotNil([item mediaPlaceholderView]);
-    XCTAssertNil([item mediaView], @"Media view should be nil if image is nil");
+    NSString *senderId = @"324543-43556-212343";
+    NSString *senderDisplayName = @"Jesse Squires";
+    NSDate *date = [NSDate date];
+    JSQMessage *message = [[JSQMessage alloc] initWithSenderId:senderId senderDisplayName:senderDisplayName date:date media:item];
+    JSQMessagesCollectionViewFlowLayout *layout = [[JSQMessagesCollectionViewFlowLayout alloc] init];
+    JSQMessagesCollectionView *collectionView = [[JSQMessagesCollectionView alloc] initWithFrame:CGRectMake(0, 0, 500, 500) collectionViewLayout:layout];
+    
+    XCTAssertNotNil(collectionView.collectionViewLayout);
+    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySizeWithMessageData:message layout:layout], CGSizeZero));
+    XCTAssertNotNil([item mediaPlaceholderViewWithMessageData:message layout:layout]);
+    XCTAssertNil([item mediaViewWithMessageData:message layout:layout], @"Media view should be nil if image is nil");
     
     item.image = [UIImage imageNamed:@"demo_avatar_jobs"];
     
-    XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+    XCTAssertNotNil([item mediaViewWithMessageData:message layout:layout], @"Media view should NOT be nil once item has media data");
+}
+
+- (void)testPhotoItemDescription
+{
+    JSQPhotoMediaItem *item = [[JSQPhotoMediaItem alloc] initWithImage:[UIImage new]];
+    XCTAssertTrue([item.description containsString:@"image"]);
+    XCTAssertTrue([item.description containsString:@"appliesMediaViewMaskAsOutgoing"]);
 }
 
 @end

--- a/JSQMessagesTests/ModelTests/JSQVideoMediaItemTests.m
+++ b/JSQMessagesTests/ModelTests/JSQVideoMediaItemTests.m
@@ -11,7 +11,8 @@
 #import <XCTest/XCTest.h>
 
 #import "JSQVideoMediaItem.h"
-
+#import "JSQMessage.h"
+#import "JSQMessagesCollectionView.h"
 
 @interface JSQVideoMediaItemTests : XCTestCase
 
@@ -42,11 +43,16 @@
     
     JSQVideoMediaItem *copy = [item copy];
     
+    JSQVideoMediaItem *newItem = [[JSQVideoMediaItem alloc] initWithFileURL:[NSURL URLWithString:@"file://123"] isReadyToPlay:YES];
+    newItem.appliesMediaViewMaskAsOutgoing = NO;
+    
     XCTAssertEqualObjects(item, copy, @"Copied items should be equal");
     
     XCTAssertEqual([item hash], [copy hash], @"Copied item hashes should be equal");
+    XCTAssertEqual([item mediaHash], [copy mediaHash], @"Copied item media hashes should be equal");
     
     XCTAssertEqualObjects(item, item, @"Item should be equal to itself");
+    XCTAssertNotEqualObjects(item, newItem);
 }
 
 - (void)testVideoItemArchiving
@@ -64,14 +70,30 @@
 {
     JSQVideoMediaItem *item = [[JSQVideoMediaItem alloc] init];
     
-    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySize], CGSizeZero));
-    XCTAssertNotNil([item mediaPlaceholderView]);
-    XCTAssertNil([item mediaView], @"Media view should be nil if fileURL is nil, and readyToPlay is NO");
+    NSString *senderId = @"324543-43556-212343";
+    NSString *senderDisplayName = @"Jesse Squires";
+    NSDate *date = [NSDate date];
+    JSQMessage *message = [[JSQMessage alloc] initWithSenderId:senderId senderDisplayName:senderDisplayName date:date media:item];
+    JSQMessagesCollectionViewFlowLayout *layout = [[JSQMessagesCollectionViewFlowLayout alloc] init];
+    JSQMessagesCollectionView *collectionView = [[JSQMessagesCollectionView alloc] initWithFrame:CGRectMake(0, 0, 500, 500) collectionViewLayout:layout];
+    
+    XCTAssertNotNil(collectionView.collectionViewLayout);
+    XCTAssertTrue(!CGSizeEqualToSize([item mediaViewDisplaySizeWithMessageData:message layout:layout], CGSizeZero));
+    XCTAssertNotNil([item mediaPlaceholderViewWithMessageData:message layout:layout]);
+    XCTAssertNil([item mediaViewWithMessageData:message layout:layout], @"Media view should be nil if fileURL is nil, and readyToPlay is NO");
     
     item.fileURL = [NSURL URLWithString:@"file://"];
     item.isReadyToPlay = YES;
     
-    XCTAssertNotNil([item mediaView], @"Media view should NOT be nil once item has media data");
+    XCTAssertNotNil([item mediaViewWithMessageData:message layout:layout], @"Media view should NOT be nil once item has media data");
+}
+
+- (void)testPhotoItemDescription
+{
+    JSQVideoMediaItem *item = [[JSQVideoMediaItem alloc] initWithFileURL:[NSURL URLWithString:@"file://"] isReadyToPlay:YES];
+    XCTAssertTrue([item.description containsString:@"fileURL"]);
+    XCTAssertTrue([item.description containsString:@"isReadyToPlay"]);
+    XCTAssertTrue([item.description containsString:@"appliesMediaViewMaskAsOutgoing"]);
 }
 
 @end

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -493,7 +493,7 @@ JSQMessagesKeyboardControllerDelegate>
     }
     else {
         id<JSQMessageMediaData> messageMedia = [messageItem media];
-        cell.mediaView = [messageMedia mediaView] ?: [messageMedia mediaPlaceholderView];
+        cell.mediaView = [messageMedia mediaViewWithMessageData:messageItem layout:self.collectionView.collectionViewLayout] ?: [messageMedia mediaPlaceholderViewWithMessageData:messageItem layout:self.collectionView.collectionViewLayout];
         NSParameterAssert(cell.mediaView != nil);
     }
 

--- a/JSQMessagesViewController/Layout/JSQAudioMediaViewAttributes.h
+++ b/JSQMessagesViewController/Layout/JSQAudioMediaViewAttributes.h
@@ -97,7 +97,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithPlayButtonImage:(UIImage *)playButtonImage
                        pauseButtonImage:(UIImage *)pauseButtonImage
                               labelFont:(UIFont *)labelFont
-                  showFractionalSecodns:(BOOL)showFractionalSeconds
+                  showFractionalSeconds:(BOOL)showFractionalSeconds
                         backgroundColor:(UIColor *)backgroundColor
                               tintColor:(UIColor *)tintColor
                           controlInsets:(UIEdgeInsets)controlInsets

--- a/JSQMessagesViewController/Layout/JSQAudioMediaViewAttributes.m
+++ b/JSQMessagesViewController/Layout/JSQAudioMediaViewAttributes.m
@@ -26,7 +26,7 @@
 - (instancetype)initWithPlayButtonImage:(UIImage *)playButtonImage
                        pauseButtonImage:(UIImage *)pauseButtonImage
                               labelFont:(UIFont *)labelFont
-                  showFractionalSecodns:(BOOL)showFractionalSeconds
+                  showFractionalSeconds:(BOOL)showFractionalSeconds
                         backgroundColor:(UIColor *)backgroundColor
                               tintColor:(UIColor *)tintColor
                           controlInsets:(UIEdgeInsets)controlInsets
@@ -66,7 +66,7 @@
     return [self initWithPlayButtonImage:[[UIImage jsq_defaultPlayImage] jsq_imageMaskedWithColor:tintColor]
                         pauseButtonImage:[[UIImage jsq_defaultPauseImage] jsq_imageMaskedWithColor:tintColor]
                                labelFont:[UIFont systemFontOfSize:12]
-                   showFractionalSecodns:NO
+                   showFractionalSeconds:NO
                          backgroundColor:[UIColor jsq_messageBubbleLightGrayColor]
                                tintColor:tintColor
                            controlInsets:UIEdgeInsetsMake(6, 6, 6, 18)

--- a/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesBubblesSizeCalculator.m
@@ -103,7 +103,7 @@
     CGSize finalSize = CGSizeZero;
 
     if ([messageData isMediaMessage]) {
-        finalSize = [[messageData media] mediaViewDisplaySize];
+        finalSize = [[messageData media] mediaViewDisplaySizeWithMessageData:messageData layout:layout];
     }
     else {
         CGSize avatarSize = [self jsq_avatarSizeForMessageData:messageData withLayout:layout];

--- a/JSQMessagesViewController/Model/JSQAudioMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQAudioMediaItem.m
@@ -27,8 +27,6 @@
 
 @interface JSQAudioMediaItem ()
 
-@property (strong, nonatomic) UIView *cachedMediaView;
-
 @property (strong, nonatomic) UIButton *playButton;
 
 @property (strong, nonatomic) UIProgressView *progressView;
@@ -50,7 +48,6 @@
 
     self = [super init];
     if (self) {
-        _cachedMediaView = nil;
         _audioData = [audioData copy];
         _audioViewAttributes = audioViewAttributes;
     }
@@ -88,7 +85,6 @@
     _progressLabel = nil;
     [self stopProgressTimer];
 
-    _cachedMediaView = nil;
     [super clearCachedMediaViews];
 }
 
@@ -104,12 +100,6 @@
 {
     _audioData = [NSData dataWithContentsOfURL:audioURL];
     [self clearCachedMediaViews];
-}
-
-- (void)setAppliesMediaViewMaskAsOutgoing:(BOOL)appliesMediaViewMaskAsOutgoing
-{
-    [super setAppliesMediaViewMaskAsOutgoing:appliesMediaViewMaskAsOutgoing];
-    _cachedMediaView = nil;
 }
 
 #pragma mark - Private
@@ -216,15 +206,16 @@
 
 #pragma mark - JSQMessageMediaData protocol
 
-- (CGSize)mediaViewDisplaySize
+- (CGSize)mediaViewDisplaySizeWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout
 {
-    return CGSizeMake(160.0f,
+    CGSize proposedSize = [super mediaViewDisplaySizeWithMessageData:messageData layout:layout];
+    return CGSizeMake(proposedSize.width,
                       self.audioViewAttributes.controlInsets.top +
                       self.audioViewAttributes.controlInsets.bottom +
                       self.audioViewAttributes.playButtonImage.size.height);
 }
 
-- (UIView *)mediaView
+- (UIView *)mediaViewWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout
 {
     if (self.audioData && self.cachedMediaView == nil) {
         if (self.audioData) {
@@ -233,7 +224,7 @@
         }
 
         // create container view for the various controls
-        CGSize size = [self mediaViewDisplaySize];
+        CGSize size = [self mediaViewDisplaySizeWithMessageData:messageData layout:layout];
         UIView * playView = [[UIView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, size.width, size.height)];
         playView.backgroundColor = self.audioViewAttributes.backgroundColor;
         playView.contentMode = UIViewContentModeCenter;

--- a/JSQMessagesViewController/Model/JSQMediaItem.h
+++ b/JSQMessagesViewController/Model/JSQMediaItem.h
@@ -17,6 +17,7 @@
 //
 
 #import "JSQMessageMediaData.h"
+#import "JSQMessageData.h"
 
 /**
  *  The `JSQMediaItem` class is an abstract base class for media item model objects that represents
@@ -31,6 +32,16 @@
  *  @see JSQVideoMediaItem.
  */
 @interface JSQMediaItem : NSObject <JSQMessageMediaData, NSCoding, NSCopying>
+
+/**
+ *  Cached view for placeholder
+ */
+@property (strong, nonatomic) UIView *cachedPlaceholderView;
+
+/**
+ *  Cached media view
+ */
+@property (strong, nonatomic) UIView *cachedMediaView;
 
 /**
  *  A boolean value indicating whether this media item should apply

--- a/JSQMessagesViewController/Model/JSQMessage.m
+++ b/JSQMessagesViewController/Model/JSQMessage.m
@@ -135,7 +135,7 @@
 
 - (id)debugQuickLookObject
 {
-    return [self.media mediaView] ?: [self.media mediaPlaceholderView];
+    return self.text;
 }
 
 #pragma mark - NSCoding

--- a/JSQMessagesViewController/Model/JSQMessageMediaData.h
+++ b/JSQMessagesViewController/Model/JSQMessageMediaData.h
@@ -18,6 +18,9 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+#import "JSQMessagesCollectionViewFlowLayout.h"
+
+@protocol JSQMessageData;
 
 /**
  *  The `JSQMessageMediaData` protocol defines the common interface through which
@@ -39,13 +42,19 @@
 @required
 
 /**
+ *  @param messageData Message for media data
+ *  @param layout Collection layout in which view will be displayed. Use it for size calculation
+ *
  *  @return An initialized `UIView` object that represents the data for this media object.
  *
  *  @discussion You may return `nil` from this method while the media data is being downloaded.
  */
-- (UIView *)mediaView;
+- (UIView *)mediaViewWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout;
 
 /**
+ *  @param messageData Message for media data
+ *  @param layout Collection layout in which view will be displayed. Use it for size calculation
+ *
  *  @return The frame size for the mediaView when displayed in a `JSQMessagesCollectionViewCell`. 
  *
  *  @discussion You should return an appropriate size value to be set for the mediaView's frame
@@ -54,9 +63,12 @@
  *
  *  @warning You must return a size with non-zero, positive width and height values.
  */
-- (CGSize)mediaViewDisplaySize;
+- (CGSize)mediaViewDisplaySizeWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout;
 
 /**
+ *  @param messageData Message for media data
+ *  @param layout Collection layout in which view will be displayed. Use it for size calculation
+ *
  *  @return A placeholder media view to be displayed if mediaView is not yet available, or `nil`.
  *  For example, if mediaView will be constructed based on media data that must be downloaded,
  *  this placeholder view will be used until mediaView is not `nil`.
@@ -68,7 +80,7 @@
  *
  *  @see JSQMessagesMediaPlaceholderView.
  */
-- (UIView *)mediaPlaceholderView;
+- (UIView *)mediaPlaceholderViewWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout;
 
 /**
  *  @return An integer that can be used as a table address in a hash table structure.

--- a/JSQMessagesViewController/Model/JSQVideoMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQVideoMediaItem.m
@@ -23,16 +23,9 @@
 
 #import "UIImage+JSQMessages.h"
 
-
-@interface JSQVideoMediaItem ()
-
-@property (strong, nonatomic) UIImageView *cachedVideoImageView;
-
-@end
-
-
 @implementation JSQVideoMediaItem
 
+@synthesize cachedMediaView = _cachedMediaView;
 #pragma mark - Initialization
 
 - (instancetype)initWithFileURL:(NSURL *)fileURL isReadyToPlay:(BOOL)isReadyToPlay
@@ -41,15 +34,8 @@
     if (self) {
         _fileURL = [fileURL copy];
         _isReadyToPlay = isReadyToPlay;
-        _cachedVideoImageView = nil;
     }
     return self;
-}
-
-- (void)clearCachedMediaViews
-{
-    [super clearCachedMediaViews];
-    _cachedVideoImageView = nil;
 }
 
 #pragma mark - Setters
@@ -57,31 +43,25 @@
 - (void)setFileURL:(NSURL *)fileURL
 {
     _fileURL = [fileURL copy];
-    _cachedVideoImageView = nil;
+    _cachedMediaView = nil;
 }
 
 - (void)setIsReadyToPlay:(BOOL)isReadyToPlay
 {
     _isReadyToPlay = isReadyToPlay;
-    _cachedVideoImageView = nil;
-}
-
-- (void)setAppliesMediaViewMaskAsOutgoing:(BOOL)appliesMediaViewMaskAsOutgoing
-{
-    [super setAppliesMediaViewMaskAsOutgoing:appliesMediaViewMaskAsOutgoing];
-    _cachedVideoImageView = nil;
+    _cachedMediaView = nil;
 }
 
 #pragma mark - JSQMessageMediaData protocol
 
-- (UIView *)mediaView
+- (UIView *)mediaViewWithMessageData:(id<JSQMessageData>)messageData layout:(JSQMessagesCollectionViewFlowLayout *)layout
 {
     if (self.fileURL == nil || !self.isReadyToPlay) {
         return nil;
     }
     
-    if (self.cachedVideoImageView == nil) {
-        CGSize size = [self mediaViewDisplaySize];
+    if (self.cachedMediaView == nil) {
+        CGSize size = [self mediaViewDisplaySizeWithMessageData:messageData layout:layout];
         UIImage *playIcon = [[UIImage jsq_defaultPlayImage] jsq_imageMaskedWithColor:[UIColor lightGrayColor]];
         
         UIImageView *imageView = [[UIImageView alloc] initWithImage:playIcon];
@@ -90,10 +70,10 @@
         imageView.contentMode = UIViewContentModeCenter;
         imageView.clipsToBounds = YES;
         [JSQMessagesMediaViewBubbleImageMasker applyBubbleImageMaskToMediaView:imageView isOutgoing:self.appliesMediaViewMaskAsOutgoing];
-        self.cachedVideoImageView = imageView;
+        self.cachedMediaView = imageView;
     }
     
-    return self.cachedVideoImageView;
+    return self.cachedMediaView;
 }
 
 - (NSUInteger)mediaHash


### PR DESCRIPTION
# Pull request checklist

- [x]  I have resolved any merge conflicts. 
- [x]  I have squashed my commits into 1 commit.
- [x]  I have followed the coding style, and reviewed the contributing guidelines. Confirmation: :muscle::sunglasses::facepunch:
- [x]  All tests pass. Demo project builds and runs.

This fixes issue #797 .

# What's in this pull request?

Extend delegate methods for JSQMediaItem. Now you can easily calculate mediaViewSize  base on real layout data.