### PR TITLE
invalidate layout on viewDidLayoutSubviews if necessary to address #1257

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -132,6 +132,8 @@ JSQMessagesKeyboardControllerDelegate>
 
 @property (assign, nonatomic) BOOL jsq_isObserving;
 
+@property (nonatomic) CGFloat jsq_collectionViewFrameWidth;
+
 @property (strong, nonatomic) NSIndexPath *selectedIndexPathForMenu;
 
 @property (weak, nonatomic) UIGestureRecognizer *currentInteractivePopGestureRecognizer;
@@ -267,6 +269,8 @@ JSQMessagesKeyboardControllerDelegate>
 
     [[[self class] nib] instantiateWithOwner:self options:nil];
 
+    self.jsq_collectionViewFrameWidth = CGRectGetWidth(self.collectionView.frame);
+
     [self jsq_configureMessagesViewController];
     [self jsq_registerForNotifications:YES];
 }
@@ -310,6 +314,12 @@ JSQMessagesKeyboardControllerDelegate>
     if (!self.inputToolbar.contentView.textView.isFirstResponder) {
         [self jsq_setToolbarBottomLayoutGuideConstant:self.bottomLayoutGuide.length];
     }
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+    [self jsq_resetLayoutAndCaches];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -370,9 +380,15 @@ JSQMessagesKeyboardControllerDelegate>
 
 - (void)jsq_resetLayoutAndCaches
 {
-    JSQMessagesCollectionViewFlowLayoutInvalidationContext *context = [JSQMessagesCollectionViewFlowLayoutInvalidationContext context];
-    context.invalidateFlowLayoutMessagesCache = YES;
-    [self.collectionView.collectionViewLayout invalidateLayoutWithContext:context];
+    if (CGRectGetWidth(self.collectionView.frame) != self.jsq_collectionViewFrameWidth) {
+
+        self.jsq_collectionViewFrameWidth = CGRectGetWidth(self.collectionView.frame);
+
+        // invalidate layout
+        JSQMessagesCollectionViewFlowLayoutInvalidationContext *context = [JSQMessagesCollectionViewFlowLayoutInvalidationContext context];
+        context.invalidateFlowLayoutMessagesCache = YES;
+        [self.collectionView.collectionViewLayout invalidateLayoutWithContext:context];
+    }
 }
 
 #pragma mark - Messages view controller


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: _EH_

#### This fixes issue #1257 .

## What's in this pull request?

Invalidate the collection view layout if the view width has changed when viewDidLayoutSubviews is called. This can happen when running on an iPhone 6, 6+, or iPad.

