### PR TITLE
Swift - Add support to simulate incoming text and image messages

### DIFF
--- a/SwiftExample/SwiftExample/ChatViewController.swift
+++ b/SwiftExample/SwiftExample/ChatViewController.swift
@@ -113,7 +113,7 @@ class ChatViewController: JSQMessagesViewController {
                 
                 newMediaData = photoItemCopy
             default:
-                print("error: unrecognized media item")
+                assertionFailure("Error: unrecognized media item")
             }
             
             newMessage = JSQMessage(senderId: AvatarIdJobs, displayName: DisplayNameJobs, media: newMediaData)
@@ -156,7 +156,7 @@ class ChatViewController: JSQMessagesViewController {
                     (newMediaData as! JSQPhotoMediaItem).image = newMediaAttachmentCopy as! UIImage
                     self.collectionView.reloadData()
                 default:
-                    print("error: unrecognized media item")
+                    assertionFailure("Error: unrecognized media item")
                 }
             }
         }

--- a/SwiftExample/SwiftExample/ChatViewController.swift
+++ b/SwiftExample/SwiftExample/ChatViewController.swift
@@ -113,7 +113,7 @@ class ChatViewController: JSQMessagesViewController {
                 
                 newMediaData = photoItemCopy
             default:
-                assertionFailure("Error: unrecognized media item")
+                assertionFailure("Error: This Media type was not recognised")
             }
             
             newMessage = JSQMessage(senderId: AvatarIdJobs, displayName: DisplayNameJobs, media: newMediaData)
@@ -156,7 +156,7 @@ class ChatViewController: JSQMessagesViewController {
                     (newMediaData as! JSQPhotoMediaItem).image = newMediaAttachmentCopy as! UIImage
                     self.collectionView.reloadData()
                 default:
-                    assertionFailure("Error: unrecognized media item")
+                    assertionFailure("Error: This Media type was not recognised")
                 }
             }
         }

--- a/SwiftExample/SwiftExample/ChatViewController.swift
+++ b/SwiftExample/SwiftExample/ChatViewController.swift
@@ -41,6 +41,9 @@ class ChatViewController: JSQMessagesViewController {
         collectionView?.collectionViewLayout.incomingAvatarViewSize = .zero
         collectionView?.collectionViewLayout.outgoingAvatarViewSize = .zero
         
+        // Show Button to simulate incoming messages
+        self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: UIImage.jsq_defaultTypingIndicatorImage(), style: .Plain, target: self, action: #selector(receiveMessagePressed))
+        
         // This is a beta feature that mostly works but to make things more stable I have diabled it.
         collectionView?.collectionViewLayout.springinessEnabled = false
         
@@ -55,10 +58,109 @@ class ChatViewController: JSQMessagesViewController {
         self.messages = makeConversation()
         self.collectionView?.reloadData()
         self.collectionView?.layoutIfNeeded()
-        
-        
     }
     
+    func receiveMessagePressed(sender: UIBarButtonItem) {
+        /**
+         *  DEMO ONLY
+         *
+         *  The following is simply to simulate received messages for the demo.
+         *  Do not actually do this.
+         */
+        
+        
+        /**
+         *  Show the typing indicator to be shown
+         */
+        self.showTypingIndicator = !self.showTypingIndicator
+        
+        /**
+         *  Scroll to actually view the indicator
+         */
+        self.scrollToBottomAnimated(true)
+        
+        /**
+         *  Copy last sent message, this will be the new "received" message
+         */
+        var copyMessage = self.messages.last?.copy()
+        
+        if (copyMessage == nil) {
+            copyMessage = JSQMessage(senderId: AvatarIdJobs, displayName: DisplayNameJobs, text: "First received!")
+        }
+            
+        var newMessage:JSQMessage?
+        var newMediaData:JSQMessageMediaData?
+        var newMediaAttachmentCopy:AnyObject?
+        
+        if copyMessage!.isMediaMessage() {
+            /**
+             *  Last message was a media message
+             */
+            let copyMediaData = copyMessage!.media
+            
+            switch copyMediaData {
+            case is JSQPhotoMediaItem:
+                let photoItemCopy = (copyMediaData as! JSQPhotoMediaItem).copy() as! JSQPhotoMediaItem
+                photoItemCopy.appliesMediaViewMaskAsOutgoing = false
+                
+                newMediaAttachmentCopy = UIImage(CGImage: photoItemCopy.image.CGImage!)
+                
+                /**
+                 *  Set image to nil to simulate "downloading" the image
+                 *  and show the placeholder view5017
+                 */
+                photoItemCopy.image = nil;
+                
+                newMediaData = photoItemCopy
+            default:
+                print("error: unrecognized media item")
+            }
+            
+            newMessage = JSQMessage(senderId: AvatarIdJobs, displayName: DisplayNameJobs, media: newMediaData)
+        }
+        else {
+            /**
+             *  Last message was a text message
+             */
+            
+            newMessage = JSQMessage(senderId: AvatarIdJobs, displayName: DisplayNameJobs, text: copyMessage!.text)
+        }
+        
+        /**
+         *  Upon receiving a message, you should:
+         *
+         *  1. Play sound (optional)
+         *  2. Add new JSQMessageData object to your data source
+         *  3. Call `finishReceivingMessage`
+         */
+        
+        JSQSystemSoundPlayer.jsq_playMessageReceivedSound()
+        self.messages.append(newMessage!)
+        self.finishReceivingMessageAnimated(true)
+        
+        if newMessage!.isMediaMessage {
+            /**
+             *  Simulate "downloading" media
+             */
+            dispatch_after(dispatch_time(DISPATCH_TIME_NOW, Int64(1 * Double(NSEC_PER_SEC))), dispatch_get_main_queue()) {
+                /**
+                 *  Media is "finished downloading", re-display visible cells
+                 *
+                 *  If media cell is not visible, the next time it is dequeued the view controller will display its new attachment data
+                 *
+                 *  Reload the specific item, or simply call `reloadData`
+                 */
+                
+                switch newMediaData {
+                case is JSQPhotoMediaItem:
+                    (newMediaData as! JSQPhotoMediaItem).image = newMediaAttachmentCopy as! UIImage
+                    self.collectionView.reloadData()
+                default:
+                    print("error: unrecognized media item")
+                }
+            }
+        }
+    }
     
     // MARK: JSQMessagesViewController method overrides
     override func didPressSendButton(button: UIButton?, withMessageText text: String?, senderId: String?, senderDisplayName: String?, date: NSDate?) {

--- a/SwiftExample/SwiftExampleTests/ChatViewControllerTests.swift
+++ b/SwiftExample/SwiftExampleTests/ChatViewControllerTests.swift
@@ -63,4 +63,56 @@ class ChatViewControllerTests: XCTestCase {
         XCTAssert(newMessage.media is JSQPhotoMediaItem)
         
     }
+    
+    /**
+     * Test when the messages array is empty, it should add a new incoming text message
+     * Test when the messages array last message is a text message, it should add a new incoming text message
+     */
+    func testSimulatedIncomingTextMessage() {
+        self.chatViewController.messages = []
+        self.chatViewController.collectionView.reloadData()
+        
+        // trigger action
+        let rightBarButton = self.chatViewController.navigationItem.rightBarButtonItem!
+        rightBarButton.target!.performSelector(rightBarButton.action, withObject: rightBarButton)
+        
+        let lastMessage = self.chatViewController.messages.last!
+        
+        XCTAssert(!lastMessage.isMediaMessage)
+        XCTAssert(lastMessage.senderId != self.chatViewController.senderId)
+        XCTAssert(lastMessage.senderDisplayName != self.chatViewController.senderDisplayName)
+        
+        // triger action
+        rightBarButton.target!.performSelector(rightBarButton.action, withObject: rightBarButton)
+        
+        let newMessage = self.chatViewController.messages.last!
+        
+        XCTAssert(newMessage != lastMessage)
+        XCTAssert(!newMessage.isMediaMessage)
+        XCTAssert(newMessage.senderId != self.chatViewController.senderId)
+        XCTAssert(newMessage.senderDisplayName != self.chatViewController.senderDisplayName)
+    }
+    
+    /**
+     * Simulate that last message is an image and test message received functionality
+     */
+    func testSimulatedIncomingImage() {
+        
+        // add image
+        let photoItem = JSQPhotoMediaItem(image: UIImage(named: "goldengate"))
+        self.chatViewController.addMedia(photoItem)
+        
+        let lastMessage = self.chatViewController.messages.last!
+        
+        // trigger action
+        let rightBarButton = self.chatViewController.navigationItem.rightBarButtonItem!
+        rightBarButton.target!.performSelector(rightBarButton.action, withObject: rightBarButton)
+        
+        let newMessage = self.chatViewController.messages.last!
+        
+        XCTAssert(newMessage != lastMessage)
+        XCTAssert(newMessage.media is JSQPhotoMediaItem)
+        XCTAssert(newMessage.senderId != self.chatViewController.senderId)
+        XCTAssert(newMessage.senderDisplayName != self.chatViewController.senderDisplayName)
+    }
 }


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This references issue #1608 .

## What's in this pull request?
Simulate incoming message for text and images (testing included). Let me know when you have time to check it out @MacMeDan 

