### PR TITLE
fix crash on iOS 9 when interacting with notification banner #1631

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -39,7 +39,7 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
 
 @property (assign, nonatomic) BOOL jsq_isObserving;
 
-@property (weak, nonatomic) UIView *keyboardView;
+@property (strong, nonatomic) UIView *keyboardView;
 
 @end
 


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This fixes issue #1631.

## What's in this pull request?

A memory management change to fix a KVO-related exception `'NSInternalInconsistencyException', reason: 'An instance 0x13803c8e0 of class UIInputSetHostView was deallocated while key value observers were still registered with it.`

