### PR TITLE
Improve JSQMessagesToolbarButtonFactory

### DIFF
--- a/JSQMessagesTests/FactoryTests/JSQMessagesToolbarButtonFactoryTests.m
+++ b/JSQMessagesTests/FactoryTests/JSQMessagesToolbarButtonFactoryTests.m
@@ -17,21 +17,38 @@
 
 @interface JSQMessagesToolbarButtonFactoryTests : XCTestCase
 
+@property (strong, nonatomic) JSQMessagesToolbarButtonFactory *factory;
+@property (strong, nonatomic) UIFont *factoryFont;
+
 @end
 
 
 @implementation JSQMessagesToolbarButtonFactoryTests
 
+- (void)setUp {
+    [super setUp];
+    self.factoryFont = [UIFont systemFontOfSize:15.0];
+    self.factory = [[JSQMessagesToolbarButtonFactory alloc] initWithFont:self.factoryFont];
+}
+
+- (void)tearDown {
+    [super tearDown];
+    self.factoryFont = nil;
+    self.factory = nil;
+}
+
 - (void)testDefaultSendButtonItem
 {
-    UIButton *button = [JSQMessagesToolbarButtonFactory defaultSendButtonItem];
+    UIButton *button = [self.factory defaultSendButtonItem];
     XCTAssertNotNil(button, @"Button should not be nil");
+    XCTAssertEqual(button.titleLabel.font, self.factoryFont, @"Button should use font provided by factory");
 }
 
 - (void)testDefaultAccessoryButtonItem
 {
-    UIButton *button = [JSQMessagesToolbarButtonFactory defaultAccessoryButtonItem];
+    UIButton *button = [self.factory defaultAccessoryButtonItem];
     XCTAssertNotNil(button, @"Button should not be nil");
+    XCTAssertEqual(button.titleLabel.font, self.factoryFont, @"Button should use font provided by factory");
 }
 
 @end

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
@@ -26,8 +26,16 @@
 @interface JSQMessagesToolbarButtonFactory : NSObject
 
 /**
- *  Creates and returns a new instance of `JSQMessagesToolbarButtonFactory` that use provided font for producing
- *  buttons.
+ *  Creates and returns a new instance of JSQMessagesToolbarButtonFactory that uses
+ *  the default font for creating buttons.
+ *
+ *  @return An initialized `JSQMessagesToolbarButtonFactory` object if created successfully, `nil` otherwise.
+ */
+- (instancetype)init;
+
+/**
+ *  Creates and returns a new instance of JSQMessagesToolbarButtonFactory that uses 
+ *  the specified font for creating buttons.
  *
  *  @param A font that will be used for the buttons produced by the factory.
  *

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
@@ -26,7 +26,7 @@
 @interface JSQMessagesToolbarButtonFactory : NSObject
 
 /**
- *  Creates and returns a new instance of JSQMessagesToolbarButtonFactory that uses
+ *  Creates and returns a new instance of `JSQMessagesToolbarButtonFactory` that uses
  *  the default font for creating buttons.
  *
  *  @return An initialized `JSQMessagesToolbarButtonFactory` object if created successfully, `nil` otherwise.
@@ -34,7 +34,7 @@
 - (instancetype)init;
 
 /**
- *  Creates and returns a new instance of JSQMessagesToolbarButtonFactory that uses 
+ *  Creates and returns a new instance of `JSQMessagesToolbarButtonFactory` that uses
  *  the specified font for creating buttons.
  *
  *  @param A font that will be used for the buttons produced by the factory.

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
@@ -26,12 +26,22 @@
 @interface JSQMessagesToolbarButtonFactory : NSObject
 
 /**
+ *  Creates and returns a new instance of `JSQMessagesToolbarButtonFactory` that use provided font for producing
+ *  buttons.
+ *
+ *  @param A font that will be used for the buttons produced by the factory.
+ *
+ *  @return An initialized `JSQMessagesToolbarButtonFactory` object if created successfully, `nil` otherwise.
+ */
+- (instancetype)initWithFont:(UIFont *)font;
+
+/**
  *  Creates and returns a new button that is styled as the default accessory button. 
  *  The button has a paper clip icon image and no text.
  *
  *  @return A newly created button.
  */
-+ (UIButton *)defaultAccessoryButtonItem;
+- (UIButton *)defaultAccessoryButtonItem;
 
 /**
  *  Creates and returns a new button that is styled as the default send button. 
@@ -39,6 +49,6 @@
  *
  *  @return A newly created button.
  */
-+ (UIButton *)defaultSendButtonItem;
+- (UIButton *)defaultSendButtonItem;
 
 @end

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.m
@@ -30,6 +30,11 @@
 
 @implementation JSQMessagesToolbarButtonFactory
 
+- (instancetype)init
+{
+    return [self initWithFont:[UIFont boldSystemFontOfSize:17.0]];
+}
+
 - (instancetype)initWithFont:(UIFont *)font
 {
     NSParameterAssert(font != nil);
@@ -55,7 +60,7 @@
     accessoryButton.contentMode = UIViewContentModeScaleAspectFit;
     accessoryButton.backgroundColor = [UIColor clearColor];
     accessoryButton.tintColor = [UIColor lightGrayColor];
-    accessoryButton.titleLabel.font = self.buttonFont != nil ? self.buttonFont : [UIFont boldSystemFontOfSize:17.0];
+    accessoryButton.titleLabel.font = self.buttonFont;
     
     accessoryButton.accessibilityLabel = [NSBundle jsq_localizedStringForKey:@"accessory_button_accessibility_label"];
 
@@ -72,7 +77,7 @@
     [sendButton setTitleColor:[[UIColor jsq_messageBubbleBlueColor] jsq_colorByDarkeningColorWithValue:0.1f] forState:UIControlStateHighlighted];
     [sendButton setTitleColor:[UIColor lightGrayColor] forState:UIControlStateDisabled];
 
-    sendButton.titleLabel.font = self.buttonFont != nil ? self.buttonFont : [UIFont boldSystemFontOfSize:17.0];
+    sendButton.titleLabel.font = self.buttonFont;
     sendButton.titleLabel.adjustsFontSizeToFitWidth = YES;
     sendButton.titleLabel.minimumScaleFactor = 0.85f;
     sendButton.contentMode = UIViewContentModeCenter;

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.m
@@ -22,10 +22,27 @@
 #import "UIImage+JSQMessages.h"
 #import "NSBundle+JSQMessages.h"
 
+@interface JSQMessagesToolbarButtonFactory ()
+
+@property (strong, nonatomic, readonly) UIFont *buttonFont;
+
+@end
 
 @implementation JSQMessagesToolbarButtonFactory
 
-+ (UIButton *)defaultAccessoryButtonItem
+- (instancetype)initWithFont:(UIFont *)font
+{
+    NSParameterAssert(font != nil);
+    
+    self = [super init];
+    if (self) {
+        _buttonFont = font;
+    }
+    
+    return self;
+}
+
+- (UIButton *)defaultAccessoryButtonItem
 {
     UIImage *accessoryImage = [UIImage jsq_defaultAccessoryImage];
     UIImage *normalImage = [accessoryImage jsq_imageMaskedWithColor:[UIColor lightGrayColor]];
@@ -38,13 +55,14 @@
     accessoryButton.contentMode = UIViewContentModeScaleAspectFit;
     accessoryButton.backgroundColor = [UIColor clearColor];
     accessoryButton.tintColor = [UIColor lightGrayColor];
+    accessoryButton.titleLabel.font = self.buttonFont != nil ? self.buttonFont : [UIFont boldSystemFontOfSize:17.0];
     
     accessoryButton.accessibilityLabel = [NSBundle jsq_localizedStringForKey:@"accessory_button_accessibility_label"];
 
     return accessoryButton;
 }
 
-+ (UIButton *)defaultSendButtonItem
+- (UIButton *)defaultSendButtonItem
 {
     NSString *sendTitle = [NSBundle jsq_localizedStringForKey:@"send"];
 
@@ -54,7 +72,7 @@
     [sendButton setTitleColor:[[UIColor jsq_messageBubbleBlueColor] jsq_colorByDarkeningColorWithValue:0.1f] forState:UIControlStateHighlighted];
     [sendButton setTitleColor:[UIColor lightGrayColor] forState:UIControlStateDisabled];
 
-    sendButton.titleLabel.font = [UIFont boldSystemFontOfSize:17.0f];
+    sendButton.titleLabel.font = self.buttonFont != nil ? self.buttonFont : [UIFont boldSystemFontOfSize:17.0];
     sendButton.titleLabel.adjustsFontSizeToFitWidth = YES;
     sendButton.titleLabel.minimumScaleFactor = 0.85f;
     sendButton.contentMode = UIViewContentModeCenter;

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
@@ -62,8 +62,9 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
 
     [self jsq_addObservers];
 
-    self.contentView.leftBarButtonItem = [JSQMessagesToolbarButtonFactory defaultAccessoryButtonItem];
-    self.contentView.rightBarButtonItem = [JSQMessagesToolbarButtonFactory defaultSendButtonItem];
+    JSQMessagesToolbarButtonFactory *toolbarButtonFactory = [[JSQMessagesToolbarButtonFactory alloc] initWithFont:[UIFont boldSystemFontOfSize:17.0]];
+    self.contentView.leftBarButtonItem = [toolbarButtonFactory defaultAccessoryButtonItem];
+    self.contentView.rightBarButtonItem = [toolbarButtonFactory defaultSendButtonItem];
 
     [self toggleSendButtonEnabled];
 }


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This fixes issue #866.

## What's in this pull request?

`JSQMessagesToolbarButtonFactory` now should be initialized with a button font. Class methods are instance methods.
If font isn't provided to the `JSQMessagesToolbarButtonFactory` then default `[UIFont boldSystemFontOfSize:17.0]` will be used.
