### PR TITLE
Fix issue #1583: Don't highlight cell outside message bubble (when lo…

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -237,6 +237,15 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 -(void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event{
 }
 
+-(void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event{
+}
+
+-(void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event{
+}
+
+-(void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event{
+}
+
 - (void)forwardInvocation:(NSInvocation *)anInvocation
 {
     if ([jsqMessagesCollectionViewCellActions containsObject:NSStringFromSelector(anInvocation.selector)]) {

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -211,12 +211,14 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 - (void)setHighlighted:(BOOL)highlighted
 {
     [super setHighlighted:highlighted];
+    self.avatarImageView.highlighted = highlighted;
     self.messageBubbleImageView.highlighted = highlighted;
 }
 
 - (void)setSelected:(BOOL)selected
 {
     [super setSelected:selected];
+    self.avatarImageView.highlighted = selected;
     self.messageBubbleImageView.highlighted = selected;
 }
 
@@ -230,6 +232,9 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     }
 
     return [super respondsToSelector:aSelector];
+}
+
+-(void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event{
 }
 
 - (void)forwardInvocation:(NSInvocation *)anInvocation
@@ -368,7 +373,7 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
         return CGRectContainsPoint(self.messageBubbleContainerView.frame, touchPt);
     }
     
-    return YES;
+    return NO;
 }
 
 @end


### PR DESCRIPTION
Hi guys,

## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation:  💪😎👊

#### This fixes issue #1583.

## What's in this pull request?

>
override "TouchesBegan" for JSQMessagesCollectionViewCell for denying the avatar to highlight on cell selection