### PR TITLE
Add new method cancelReceivingMessage to the JSQMessagesViewController

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -240,6 +240,11 @@
 - (void)finishReceivingMessageAnimated:(BOOL)animated;
 
 /**
+ *  Cancels the "receiving" of a message by hiding the typing indicator.
+ */
+- (void)cancelReceivingMessage;
+
+/**
  *  Scrolls the collection view such that the bottom most cell is completely visible, above the `inputToolbar`.
  *
  *  @param animated Pass `YES` if you want to animate scrolling, `NO` if it should be immediate.

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -379,6 +379,26 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
     UIAccessibilityPostNotification(UIAccessibilityAnnouncementNotification, [NSBundle jsq_localizedStringForKey:@"new_message_received_accessibility_announcement"]);
 }
 
+- (void)cancelReceivingMessage
+{
+    CGRect visibleRect = (CGRect){.origin = self.collectionView.contentOffset, .size = self.collectionView.bounds.size};
+    CGFloat visibleRectBottom = CGRectGetMaxY(visibleRect);
+    BOOL isTypingIndicatorVisible = self.collectionView.contentSize.height - visibleRectBottom <= 0;
+
+    if (isTypingIndicatorVisible && [self.collectionView numberOfItemsInSection:0] > 0) {
+        NSIndexPath *lastIndexPath = [NSIndexPath indexPathForRow:[self.collectionView numberOfItemsInSection:0] - 1
+                                                        inSection:0];
+        [self.collectionView scrollToItemAtIndexPath:lastIndexPath
+                                    atScrollPosition:UICollectionViewScrollPositionBottom
+                                            animated:YES];
+        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
+            self.showTypingIndicator = NO;
+        });
+    } else {
+        self.showTypingIndicator = NO;
+    }
+}
+
 - (void)scrollToBottomAnimated:(BOOL)animated
 {
     if ([self.collectionView numberOfSections] == 0) {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This fixes issue #898 .

## What's in this pull request?

New method `cancelReceivingMessage` was added to allow users hide typing indicator with animation. Currently, if we call `finishReceivingMessageAnimated:` but won't add new messages to the data source the typing indicator will just blink and disappear.
The way to animate this is to scroll collection view a bit up to hide typing indicator and after that remove it from the view. Solution with `dispatch_after` isn't perfect, maybe it is better to use `scrollViewDidEndDecelerating`.

### Comparison: 
`finishReceivingMessageAnimated:` vs `cancelReceivingMessage`

<img src="http://i.imgur.com/KM3xt3M.gif" height="240"> <img src="http://imgur.com/dsHqTbu.gif" height="240">