### PR TITLE
Fix issue #1583: Don't highlight cell outside message bubble (when lo…

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -212,12 +212,14 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 - (void)setHighlighted:(BOOL)highlighted
 {
     [super setHighlighted:highlighted];
+    self.avatarImageView.highlighted = highlighted;
     self.messageBubbleImageView.highlighted = highlighted;
 }
 
 - (void)setSelected:(BOOL)selected
 {
     [super setSelected:selected];
+    self.avatarImageView.highlighted = selected;
     self.messageBubbleImageView.highlighted = selected;
 }
 
@@ -245,6 +247,9 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     }
 
     return [super respondsToSelector:aSelector];
+}
+
+-(void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event{
 }
 
 - (void)forwardInvocation:(NSInvocation *)anInvocation
@@ -383,7 +388,7 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
         return CGRectContainsPoint(self.messageBubbleContainerView.frame, touchPt);
     }
     
-    return YES;
+    return NO;
 }
 
 @end


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____

#### This fixes issue #1583 without waiting for 8.0 upgrade.

## What's in this pull request?

I cherry picked this from develop, where it was already merged(https://github.com/jessesquires/JSQMessagesViewController/pull/1583). There are lots of changes accruing in develop (and it looks like many more to come) before the 8.0 merge. Is there any way we can get this in master as it seems like 8.0 release is quite ambitious and probably a ways off yet?

**Original Commit**
> In summary, overriden "touchesBegan" gaining all touch control of the JSQMessagesCollectionViewCell touches