### PR TITLE
Add dynamic text sizing Closes #497

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -106,10 +106,6 @@
                                                                                               target:self
                                                                                               action:@selector(closePressed:)];
     }
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(preferredContentSizeChanged:)
-                                                 name:UIContentSizeCategoryDidChangeNotification
-                                               object:nil];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -124,10 +120,7 @@
     self.collectionView.collectionViewLayout.springinessEnabled = [NSUserDefaults springinessSetting];
 }
 
-- (void)preferredContentSizeChanged:(NSNotification *)notification
-{
-    [self.collectionView layoutSubviews];
-}
+
 
 
 -(void) viewWillDisappear:(BOOL)animated

--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -106,6 +106,10 @@
                                                                                               target:self
                                                                                               action:@selector(closePressed:)];
     }
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(preferredContentSizeChanged:)
+                                                 name:UIContentSizeCategoryDidChangeNotification
+                                               object:nil];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -120,7 +124,17 @@
     self.collectionView.collectionViewLayout.springinessEnabled = [NSUserDefaults springinessSetting];
 }
 
+- (void)preferredContentSizeChanged:(NSNotification *)notification
+{
+    [self.collectionView layoutSubviews];
+}
 
+
+-(void) viewWillDisappear:(BOOL)animated
+{
+    [super viewWillDisappear:animated];
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+}
 
 #pragma mark - Custom menu actions for cells
 

--- a/JSQMessagesTests/FactoryTests/JSQMessagesTimestampFormatterTests.m
+++ b/JSQMessagesTests/FactoryTests/JSQMessagesTimestampFormatterTests.m
@@ -40,11 +40,11 @@
     NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
     paragraphStyle.alignment = NSTextAlignmentCenter;
     
-    NSDictionary *dateAttrs = @{ NSFontAttributeName : [UIFont boldSystemFontOfSize:12.0f],
+    NSDictionary *dateAttrs = @{ NSFontAttributeName : [UIFont preferredFontForTextStyle:UIFontTextStyleBody],
                                  NSForegroundColorAttributeName : color,
                                  NSParagraphStyleAttributeName : paragraphStyle };
     
-    NSDictionary *timeAttrs = @{ NSFontAttributeName : [UIFont systemFontOfSize:12.0f],
+    NSDictionary *timeAttrs = @{ NSFontAttributeName : [UIFont preferredFontForTextStyle:UIFontTextStyleBody],
                                  NSForegroundColorAttributeName : color,
                                  NSParagraphStyleAttributeName : paragraphStyle };
     

--- a/JSQMessagesTests/LayoutTests/JSQMessagesCollectionViewLayoutAttributesTests.m
+++ b/JSQMessagesTests/LayoutTests/JSQMessagesCollectionViewLayoutAttributesTests.m
@@ -33,7 +33,7 @@
 {
     NSIndexPath *indexPath = [NSIndexPath indexPathForItem:0 inSection:0];
     JSQMessagesCollectionViewLayoutAttributes *attrs = [JSQMessagesCollectionViewLayoutAttributes layoutAttributesForCellWithIndexPath:indexPath];
-    attrs.messageBubbleFont = [UIFont systemFontOfSize:15.0f];
+    attrs.messageBubbleFont = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     attrs.messageBubbleContainerViewWidth = 40.0f;
     attrs.textViewTextContainerInsets = UIEdgeInsetsMake(10.0f, 8.0f, 10.0f, 8.0f);
     attrs.textViewFrameInsets = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, 6.0f);

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -233,6 +233,12 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
 
     [self jsq_configureMessagesViewController];
     [self jsq_registerForNotifications:YES];
+    
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(preferredContentSizeChanged:)
+                                                 name:UIContentSizeCategoryDidChangeNotification
+                                               object:nil];
+    
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -846,6 +852,12 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
     JSQMessagesCollectionViewCell *selectedCell = (JSQMessagesCollectionViewCell *)[self.collectionView cellForItemAtIndexPath:self.selectedIndexPathForMenu];
     selectedCell.textView.selectable = YES;
     self.selectedIndexPathForMenu = nil;
+}
+
+- (void)preferredContentSizeChanged:(NSNotification *)notification
+{
+    [self.collectionView.collectionViewLayout invalidateLayout];
+    [self.collectionView setNeedsLayout];
 }
 
 #pragma mark - Collection view utilities

--- a/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.h
@@ -35,13 +35,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The text attributes to apply to the day, month, and year components of the string representation of a given date. 
- *  The default value is a dictionary containing attributes that specify centered, light gray text and the bold system font at size `12.0f`.
+ *  The default value is a dictionary containing attributes that specify centered, light gray text and the font of UIStyleBody.
  */
 @property (copy, nonatomic) NSDictionary *dateTextAttributes;
 
 /**
  *  The text attributes to apply to the minute and hour componenents of the string representation of a given date. 
- *  The default value is a dictionary containing attributes that specify centered, light gray text and the system font at size `12.0f`.
+ *  The default value is a dictionary containing attributes that specify centered, light gray text and the font of UIStyleBody.
  */
 @property (copy, nonatomic) NSDictionary *timeTextAttributes;
 

--- a/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.h
@@ -35,13 +35,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  *  The text attributes to apply to the day, month, and year components of the string representation of a given date. 
- *  The default value is a dictionary containing attributes that specify centered, light gray text and the font of UIStyleBody.
+ *  The default value is a dictionary containing attributes that specify centered, light gray text and `UIFontTextStyleBody` font.
  */
 @property (copy, nonatomic) NSDictionary *dateTextAttributes;
 
 /**
  *  The text attributes to apply to the minute and hour componenents of the string representation of a given date. 
- *  The default value is a dictionary containing attributes that specify centered, light gray text and the font of UIStyleBody.
+ *  The default value is a dictionary containing attributes that specify centered, light gray text and `UIFontTextStyleBody` font.
  */
 @property (copy, nonatomic) NSDictionary *timeTextAttributes;
 

--- a/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesTimestampFormatter.m
@@ -55,11 +55,11 @@
         NSMutableParagraphStyle *paragraphStyle = [[NSParagraphStyle defaultParagraphStyle] mutableCopy];
         paragraphStyle.alignment = NSTextAlignmentCenter;
         
-        _dateTextAttributes = @{ NSFontAttributeName : [UIFont boldSystemFontOfSize:12.0f],
+        _dateTextAttributes = @{ NSFontAttributeName : [UIFont preferredFontForTextStyle:UIFontTextStyleBody],
                                  NSForegroundColorAttributeName : color,
                                  NSParagraphStyleAttributeName : paragraphStyle };
         
-        _timeTextAttributes = @{ NSFontAttributeName : [UIFont systemFontOfSize:12.0f],
+        _timeTextAttributes = @{ NSFontAttributeName : [UIFont preferredFontForTextStyle:UIFontTextStyleBody],
                                  NSForegroundColorAttributeName : color,
                                  NSParagraphStyleAttributeName : paragraphStyle };
     }

--- a/JSQMessagesViewController/Layout/JSQAudioMediaViewAttributes.m
+++ b/JSQMessagesViewController/Layout/JSQAudioMediaViewAttributes.m
@@ -65,7 +65,7 @@
 
     return [self initWithPlayButtonImage:[[UIImage jsq_defaultPlayImage] jsq_imageMaskedWithColor:tintColor]
                         pauseButtonImage:[[UIImage jsq_defaultPauseImage] jsq_imageMaskedWithColor:tintColor]
-                               labelFont:[UIFont systemFontOfSize:12]
+                               labelFont:[UIFont preferredFontForTextStyle:UIFontTextStyleBody]
                    showFractionalSecodns:NO
                          backgroundColor:[UIColor jsq_messageBubbleLightGrayColor]
                                tintColor:tintColor

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -113,21 +113,21 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     [self setTranslatesAutoresizingMaskIntoConstraints:NO];
 
     self.backgroundColor = [UIColor whiteColor];
-
-    
-
     self.avatarViewSize = CGSizeZero;
-
+    
+    UIFont *topLabelFont = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
     self.cellTopLabel.textAlignment = NSTextAlignmentCenter;
-    self.cellTopLabel.font = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption1)];
+    self.cellTopLabel.font = topLabelFont;
     self.cellTopLabel.textColor = [UIColor lightGrayColor];
     self.cellTopLabel.numberOfLines = 0;
-
-    self.messageBubbleTopLabel.font = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption1)];
+    
+    UIFont *messageBubbleTopLabelFont = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
+    self.messageBubbleTopLabel.font = messageBubbleTopLabelFont;
     self.messageBubbleTopLabel.textColor = [UIColor lightGrayColor];
     self.messageBubbleTopLabel.numberOfLines = 0;
-
-    self.cellBottomLabel.font = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption2)];
+    
+    UIFont *bottomLabelFont = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption2];
+    self.cellBottomLabel.font = bottomLabelFont;
     self.cellBottomLabel.textColor = [UIColor lightGrayColor];
     self.cellBottomLabel.numberOfLines = 0;
 
@@ -136,6 +136,9 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     self.cellTopLabelHeightConstraint.constant = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption1)].pointSize;
     self.messageBubbleTopLabelHeightConstraint.constant = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption1)].pointSize;
     self.cellBottomLabelHeightConstraint.constant = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption2)].pointSize;
+    self.cellTopLabelHeightConstraint.constant = topLabelFont.pointSize;
+    self.messageBubbleTopLabelHeightConstraint.constant = messageBubbleTopLabelFont.pointSize;
+    self.cellBottomLabelHeightConstraint.constant = bottomLabelFont.pointSize;
     
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(jsq_handleTapGesture:)];
     [self addGestureRecognizer:tap];

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionViewCell.m
@@ -103,6 +103,7 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
     [jsqMessagesCollectionViewCellActions addObject:NSStringFromSelector(action)];
 }
 
+
 #pragma mark - Initialization
 
 - (void)awakeFromNib
@@ -113,27 +114,29 @@ static NSMutableSet *jsqMessagesCollectionViewCellActions = nil;
 
     self.backgroundColor = [UIColor whiteColor];
 
-    self.cellTopLabelHeightConstraint.constant = 0.0f;
-    self.messageBubbleTopLabelHeightConstraint.constant = 0.0f;
-    self.cellBottomLabelHeightConstraint.constant = 0.0f;
+    
 
     self.avatarViewSize = CGSizeZero;
 
     self.cellTopLabel.textAlignment = NSTextAlignmentCenter;
-    self.cellTopLabel.font = [UIFont boldSystemFontOfSize:12.0f];
+    self.cellTopLabel.font = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption1)];
     self.cellTopLabel.textColor = [UIColor lightGrayColor];
     self.cellTopLabel.numberOfLines = 0;
 
-    self.messageBubbleTopLabel.font = [UIFont systemFontOfSize:12.0f];
+    self.messageBubbleTopLabel.font = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption1)];
     self.messageBubbleTopLabel.textColor = [UIColor lightGrayColor];
     self.messageBubbleTopLabel.numberOfLines = 0;
 
-    self.cellBottomLabel.font = [UIFont systemFontOfSize:11.0f];
+    self.cellBottomLabel.font = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption2)];
     self.cellBottomLabel.textColor = [UIColor lightGrayColor];
     self.cellBottomLabel.numberOfLines = 0;
 
     [self configureAccessoryButton];
 
+    self.cellTopLabelHeightConstraint.constant = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption1)].pointSize;
+    self.messageBubbleTopLabelHeightConstraint.constant = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption1)].pointSize;
+    self.cellBottomLabelHeightConstraint.constant = [UIFont preferredFontForTextStyle:(UIFontTextStyleCaption2)].pointSize;
+    
     UITapGestureRecognizer *tap = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(jsq_handleTapGesture:)];
     [self addGestureRecognizer:tap];
     self.tapGestureRecognizer = tap;

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -54,7 +54,7 @@
     self.scrollsToTop = NO;
     self.userInteractionEnabled = YES;
 
-    self.font = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle3];
+    self.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     self.textColor = [UIColor blackColor];
     self.textAlignment = NSTextAlignmentNatural;
 

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -54,7 +54,7 @@
     self.scrollsToTop = NO;
     self.userInteractionEnabled = YES;
 
-    self.font = [UIFont systemFontOfSize:16.0f];
+    self.font = [UIFont preferredFontForTextStyle:UIFontTextStyleTitle3];
     self.textColor = [UIColor blackColor];
     self.textAlignment = NSTextAlignmentNatural;
 


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This fixes issue #497 
 - [X] implement dynamic type for cell labels (cellTopLabel, messageBubbleTopLabel, cellBottomLabel)
 - [X] implement runtime switching

## What's in this pull request?

>Add Dynamic Text instead of hardcoded font values. Also Add refresh notification for when the Accenebility setting is changed. 

>>There is an error with a 9.3 simulator where the text will not change  found here 
http://stackoverflow.com/questions/36204330/uicontentsizecategorydidchangenotification-not-working-on-simulator-ios-9-3-doe

>>That is connected to open radar:
http://www.openradar.me/radar?id=6083508816576512.

>You can do it in old versions of the simulator. IE (9.2)

🍭