### PR TITLE
fix #1675

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -126,13 +126,13 @@
 
 - (void)didReceiveMenuWillShowNotification:(NSNotification *)notification
 {
-    [super didReceiveMenuWillShowNotification:notification];
-
     /**
      *  Display custom menu actions for cells.
      */
     UIMenuController *menu = [notification object];
     menu.menuItems = @[ [[UIMenuItem alloc] initWithTitle:@"Custom Action" action:@selector(customAction:)] ];
+    
+    [super didReceiveMenuWillShowNotification:notification];
 }
 
 

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -650,6 +650,13 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
     //  temporarily disable 'selectable' to prevent this issue
     JSQMessagesCollectionViewCell *selectedCell = (JSQMessagesCollectionViewCell *)[collectionView cellForItemAtIndexPath:indexPath];
     selectedCell.textView.selectable = NO;
+    
+    //  it will reset the font and fontcolor when selectable is NO
+    //  however, the actual font and fontcolor in textView do not get changed
+    //  in order to preserve link colors, we need to re-assign the font and fontcolor when selectable is NO
+    //  see GitHub issues #1675 and #1759
+    selectedCell.textView.textColor = selectedCell.textView.textColor;
+    selectedCell.textView.font = selectedCell.textView.font;
 
     return YES;
 }


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: @Lucashuang0802

#### This fixes issue #1675 

## What's in this pull request?
- re-assign `font` and `textColor` to `textView` since `font` and `textColor` will be resetted when `selectable` gets changed to `NO`. Ref: http://stackoverflow.com/questions/19049917/uitextview-font-is-being-reset-after-settext
- postpone the execution of `didReceiveMenuWillShowNotification` in order to include `Custom Action` the first time the menu pops up. (Minor sample app bug)

