### PR TITLE
Input bar support dynamic type

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -158,6 +158,7 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
     self.inputToolbar.contentView.textView.placeHolder = [NSBundle jsq_localizedStringForKey:@"new_message"];
     self.inputToolbar.contentView.textView.accessibilityLabel = [NSBundle jsq_localizedStringForKey:@"new_message"];
     self.inputToolbar.contentView.textView.delegate = self;
+    self.inputToolbar.contentView.textView.font = [UIFont preferredFontForTextStyle:UIFontTextStyleBody];
     [self.inputToolbar removeFromSuperview];
 
     self.automaticallyScrollsToMostRecentMessage = YES;

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.m
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.m
@@ -32,7 +32,7 @@
 
 - (instancetype)init
 {
-    return [self initWithFont:[UIFont boldSystemFontOfSize:17.0]];
+    return [self initWithFont:[UIFont preferredFontForTextStyle:UIFontTextStyleHeadline]];
 }
 
 - (instancetype)initWithFont:(UIFont *)font

--- a/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
+++ b/JSQMessagesViewController/Views/JSQMessagesInputToolbar.m
@@ -63,7 +63,7 @@ static void * kJSQMessagesInputToolbarKeyValueObservingContext = &kJSQMessagesIn
 
     [self jsq_addObservers];
 
-    JSQMessagesToolbarButtonFactory *toolbarButtonFactory = [[JSQMessagesToolbarButtonFactory alloc] initWithFont:[UIFont boldSystemFontOfSize:17.0]];
+    JSQMessagesToolbarButtonFactory *toolbarButtonFactory = [[JSQMessagesToolbarButtonFactory alloc] initWithFont:[UIFont preferredFontForTextStyle:UIFontTextStyleHeadline]];
     self.contentView.leftBarButtonItem = [toolbarButtonFactory defaultAccessoryButtonItem];
     self.contentView.rightBarButtonItem = [toolbarButtonFactory defaultSendButtonItem];
 


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This fixes issue #497

## What's in this pull request? 
>> In this pull request I took the input toolbar and made the buttons and input field support Dynamic Type. Since it was previously set to `boldSystemFontWithSize 17` I decided that `UIFontStyleHeadline` would be the closest substitute. Since it is bolder and slightly larger then regular Body Font.
This should be the last task in #497 
👽
