### PR TITLE
Custom keyboards: Make input toolbar's height configurable.

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.h
@@ -111,6 +111,11 @@ FOUNDATION_EXPORT NSString * const JSQMessagesKeyboardControllerUserInfoKeyKeybo
 @property (assign, nonatomic, readonly) CGRect currentKeyboardFrame;
 
 /**
+ *  This allows us to enable or disable the pan gesture from the outside.
+ */
+@property (assign, nonatomic) BOOL handlePanGesture;
+
+/**
  *  Not a valid initializer.
  */
 - (id)init NS_UNAVAILABLE;
@@ -139,5 +144,6 @@ FOUNDATION_EXPORT NSString * const JSQMessagesKeyboardControllerUserInfoKeyKeybo
  *  Tells the keyboard controller that it should end listening for system keyboard notifications.
  */
 - (void)endListeningForKeyboard;
+
 
 @end

--- a/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesKeyboardController.m
@@ -66,6 +66,7 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
         _panGestureRecognizer = panGestureRecognizer;
         _delegate = delegate;
         _jsq_isObserving = NO;
+        _handlePanGesture = YES;
     }
     return self;
 }
@@ -307,6 +308,10 @@ typedef void (^JSQAnimationCompletionBlock)(BOOL finished);
 
 - (void)jsq_handlePanGestureRecognizer:(UIPanGestureRecognizer *)pan
 {
+    if (!_handlePanGesture) {
+        return;
+    }
+    
     CGPoint touch = [pan locationInView:self.contextView.window];
 
     //  system keyboard is added to a new UIWindow, need to operate in window coordinates

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.h
@@ -46,6 +46,12 @@
 @property (weak, nonatomic, readonly) JSQMessagesInputToolbar *inputToolbar;
 
 /**
+ *  Returns the Auto-layout constraint for the input toolbar's height.
+ *  This is exposed here so that you can configure the input toolbar's height from the outside.
+ */
+@property (weak, nonatomic, readonly) NSLayoutConstraint *toolbarHeightConstraint;
+
+/**
  *  Returns the keyboard controller object used to manage the software keyboard.
  */
 @property (strong, nonatomic) JSQMessagesKeyboardController *keyboardController;

--- a/SwiftExample/Podfile
+++ b/SwiftExample/Podfile
@@ -4,9 +4,6 @@
  use_frameworks!
 
 target 'SwiftExample' do
-
-pod 'JSQMessagesViewController'
-
-
+	pod 'JSQMessagesViewController', :path => '../'
 end
 

--- a/SwiftExample/Podfile.lock
+++ b/SwiftExample/Podfile.lock
@@ -1,13 +1,19 @@
 PODS:
-  - JSQMessagesViewController (7.2.0):
+  - JSQMessagesViewController (7.3.4):
     - JSQSystemSoundPlayer (~> 2.0.1)
   - JSQSystemSoundPlayer (2.0.1)
 
 DEPENDENCIES:
-  - JSQMessagesViewController
+  - JSQMessagesViewController (from `../`)
+
+EXTERNAL SOURCES:
+  JSQMessagesViewController:
+    :path: ../
 
 SPEC CHECKSUMS:
-  JSQMessagesViewController: 73cab48aa92fc2d512f3b6724f3425cc47a19eb5
+  JSQMessagesViewController: 39fed975e3c9f8eba7292071e29eeb541d105e66
   JSQSystemSoundPlayer: c5850e77a4363ffd374cd851154b9af93264ed8d
 
-COCOAPODS: 0.39.0
+PODFILE CHECKSUM: e2181acc1ba556e660bf0c9cfddb1ea829ec4e23
+
+COCOAPODS: 1.0.1


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ✅

## What's in this pull request?

This commit enables one to configure key aspects of the input toolbar and the keyboard controller from the outside, in order to be able to use a custom keyboard: see attached screencast of what this allows me to build.

Thanks for your great work @jessesquires! 🤗🤗

![custom-keyboard](https://cloud.githubusercontent.com/assets/326577/17670932/96c76212-6314-11e6-8bd7-00cb23367bb3.gif)
