### PR TITLE
Invalidate flow layout msg cache on JSQMessagesCollectionView size change

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -297,16 +297,6 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
     }
 }
 
-- (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
-    [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    [self jsq_resetLayoutAndCaches];
-}
-
-- (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {
-    [super traitCollectionDidChange:previousTraitCollection];
-    [self jsq_resetLayoutAndCaches];
-}
-
 - (void)jsq_resetLayoutAndCaches
 {
     JSQMessagesCollectionViewFlowLayoutInvalidationContext *context = [JSQMessagesCollectionViewFlowLayoutInvalidationContext context];

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -297,13 +297,6 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
     }
 }
 
-- (void)jsq_resetLayoutAndCaches
-{
-    JSQMessagesCollectionViewFlowLayoutInvalidationContext *context = [JSQMessagesCollectionViewFlowLayoutInvalidationContext context];
-    context.invalidateFlowLayoutMessagesCache = YES;
-    [self.collectionView.collectionViewLayout invalidateLayoutWithContext:context];
-}
-
 #pragma mark - Messages view controller
 
 - (void)didPressSendButton:(UIButton *)button

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
@@ -26,6 +26,8 @@
 #import "JSQMessagesTypingIndicatorFooterView.h"
 #import "JSQMessagesLoadEarlierHeaderView.h"
 
+#import "JSQMessagesCollectionViewFlowLayoutInvalidationContext.h"
+
 #import "UIColor+JSQMessages.h"
 
 
@@ -36,7 +38,9 @@
 @end
 
 
-@implementation JSQMessagesCollectionView
+@implementation JSQMessagesCollectionView {
+    CGRect previousFrame;
+}
 
 @dynamic dataSource;
 @dynamic delegate;
@@ -78,6 +82,7 @@ forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
     _typingIndicatorEllipsisColor = [_typingIndicatorMessageBubbleColor jsq_colorByDarkeningColorWithValue:0.3f];
 
     _loadEarlierMessagesHeaderTextColor = [UIColor jsq_messageBubbleBlueColor];
+    previousFrame = self.frame;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout
@@ -93,6 +98,18 @@ forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
 {
     [super awakeFromNib];
     [self jsq_configureCollectionView];
+}
+
+#pragma mark - Overrides
+
+- (void)layoutSubviews {
+    if (!CGRectEqualToRect(previousFrame, self.frame)) {
+        JSQMessagesCollectionViewFlowLayoutInvalidationContext *context = [JSQMessagesCollectionViewFlowLayoutInvalidationContext context];
+        context.invalidateFlowLayoutMessagesCache = YES;
+        [self.collectionViewLayout invalidateLayoutWithContext:context];
+        previousFrame = self.frame;
+    }
+    [super layoutSubviews];
 }
 
 #pragma mark - Typing indicator

--- a/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesCollectionView.m
@@ -39,7 +39,7 @@
 
 
 @implementation JSQMessagesCollectionView {
-    CGRect previousFrame;
+    CGSize previousSize;
 }
 
 @dynamic dataSource;
@@ -82,7 +82,7 @@ forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
     _typingIndicatorEllipsisColor = [_typingIndicatorMessageBubbleColor jsq_colorByDarkeningColorWithValue:0.3f];
 
     _loadEarlierMessagesHeaderTextColor = [UIColor jsq_messageBubbleBlueColor];
-    previousFrame = self.frame;
+    previousSize = self.frame.size;
 }
 
 - (instancetype)initWithFrame:(CGRect)frame collectionViewLayout:(UICollectionViewLayout *)layout
@@ -103,11 +103,11 @@ forSupplementaryViewOfKind:UICollectionElementKindSectionHeader
 #pragma mark - Overrides
 
 - (void)layoutSubviews {
-    if (!CGRectEqualToRect(previousFrame, self.frame)) {
+    if (!CGSizeEqualToSize(previousSize, self.frame.size)) {
         JSQMessagesCollectionViewFlowLayoutInvalidationContext *context = [JSQMessagesCollectionViewFlowLayoutInvalidationContext context];
         context.invalidateFlowLayoutMessagesCache = YES;
         [self.collectionViewLayout invalidateLayoutWithContext:context];
-        previousFrame = self.frame;
+        previousSize = self.frame.size;
     }
     [super layoutSubviews];
 }


### PR DESCRIPTION
## Pull request checklist
- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____
#### This fixes issue #1844
## What's in this pull request?

Reset FlowLayoutMessagesCache at every JSQMessagesCollectionView size change
