### PR TITLE
Fix for behaviour described in issue #1709

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -238,7 +238,8 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    self.toolbarHeightConstraint.constant = self.inputToolbar.preferredDefaultHeight;
+    if (!self.inputToolbar.contentView.textView.hasText)
+        self.toolbarHeightConstraint.constant = self.inputToolbar.preferredDefaultHeight;
     [self.view layoutIfNeeded];
     [self.collectionView.collectionViewLayout invalidateLayout];
 

--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -238,8 +238,9 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
 - (void)viewWillAppear:(BOOL)animated
 {
     [super viewWillAppear:animated];
-    if (!self.inputToolbar.contentView.textView.hasText)
+    if (!self.inputToolbar.contentView.textView.hasText) {
         self.toolbarHeightConstraint.constant = self.inputToolbar.preferredDefaultHeight;
+    }
     [self.view layoutIfNeeded];
     [self.collectionView.collectionViewLayout invalidateLayout];
 


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This fixes issue #1709 

## What's in this pull request?
When entering a multiline message in the inputToolbar, the textView (and toolbar) expand to fit the entered text until reaching maximumHeight.
However, if the JSQMessagesViewController disappears (due to NavigationController actions or being embedded inside other ViewControllers) and then is made visible again, the input field has shrunk to a single line, with the entered text being kept. Entering additional lines of text makes the textView grow, but never to regain the size it had before, since the textView is grown using a delta value based on the size set upon viewWillAppear.
This fix checks upon viewWillAppear whether there already is text in the input field, and if so, does not reset the constraints constant to preferredDefaultHeight.