### PR TITLE
Properly copy attributes before modifying in JSQMessagesCollectionViewFlowLayout

### DIFF
--- a/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
+++ b/JSQMessagesViewController/Layout/JSQMessagesCollectionViewFlowLayout.m
@@ -270,7 +270,7 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
         CGFloat padding = -100.0f;
         CGRect visibleRect = CGRectInset(self.collectionView.bounds, padding, padding);
         
-        NSArray *visibleItems = [super layoutAttributesForElementsInRect:visibleRect];
+        NSArray *visibleItems = [[NSArray alloc] initWithArray:[super layoutAttributesForElementsInRect:visibleRect] copyItems:YES];
         NSSet *visibleItemsIndexPaths = [NSSet setWithArray:[visibleItems valueForKey:NSStringFromSelector(@selector(indexPath))]];
         
         [self jsq_removeNoLongerVisibleBehaviorsFromVisibleItemsIndexPaths:visibleItemsIndexPaths];
@@ -281,7 +281,7 @@ const CGFloat kJSQMessagesCollectionViewAvatarSizeDefault = 30.0f;
 
 - (NSArray *)layoutAttributesForElementsInRect:(CGRect)rect
 {
-    NSArray *attributesInRect = [[super layoutAttributesForElementsInRect:rect] copy];
+    NSArray *attributesInRect = [[NSArray alloc] initWithArray:[super layoutAttributesForElementsInRect:rect] copyItems:YES];
     
     if (self.springinessEnabled) {
         NSMutableArray *attributesInRectCopy = [attributesInRect mutableCopy];


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: ____

#### This fixes issue #1218 

## What's in this pull request?
Ensure that attributes array is properly copied before modification.
Could also fix #1424 but I'm not sure about that.
