### PR TITLE
Add Danish translation of JSQMessages.strings

### DIFF
--- a/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/da.lproj/JSQMessages.strings
+++ b/JSQMessagesViewController/Assets/JSQMessagesAssets.bundle/da.lproj/JSQMessages.strings
@@ -1,0 +1,37 @@
+//
+//  Created by Jesse Squires
+//  http://www.jessesquires.com
+//
+//
+//  Documentation
+//  http://cocoadocs.org/docsets/JSQMessagesViewController
+//
+//
+//  GitHub
+//  https://github.com/jessesquires/JSQMessagesViewController
+//
+//
+//  License
+//  Copyright (c) 2014 Jesse Squires
+//  Released under an MIT license: http://opensource.org/licenses/MIT
+//
+
+//  ********************************
+//  Special thanks to the localization contributors!
+//
+//  https://github.com/jessesquires/JSQMessagesViewController/issues/237
+//  ********************************
+
+"load_earlier_messages" = "Indlæs tidligere beskeder";
+
+"send" = "Send";
+
+"new_message" = "Ny besked";
+
+"text_message_accessibility_label" = "%@: %@";
+
+"media_message_accessibility_label" = "%@: mediebesked";
+
+"accessory_button_accessibility_label" = "Del medie";
+
+"new_message_received_accessibility_announcement" = "Ny besked modtaget";


### PR DESCRIPTION
## Pull request checklist

- [ ] All tests pass. Demo project builds and runs.
- [ ] I have resolved any merge conflicts.
- [ ] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation:  💪😎👊

#### This fixes issue #N/A

## What's in this pull request?
Danish translation.

Would really appreciate if this got backported to 7.3 as well…