### PR TITLE
Impartial localizations should fall back to base (#1903)

### DIFF
--- a/JSQMessagesViewController/Categories/NSBundle+JSQMessages.m
+++ b/JSQMessagesViewController/Categories/NSBundle+JSQMessages.m
@@ -36,7 +36,19 @@
 
 + (NSString *)jsq_localizedStringForKey:(NSString *)key
 {
-    return NSLocalizedStringFromTableInBundle(key, @"JSQMessages", [NSBundle jsq_messagesAssetBundle], nil);
+    NSString *value = NSLocalizedStringFromTableInBundle(key, @"JSQMessages", [NSBundle jsq_messagesAssetBundle], nil);
+    
+    if ([value isEqualToString:key]) {
+        // This translation is partial, and the key we're looking up is missing
+        // Fall back to the Base localization
+        if (![[[NSLocale preferredLanguages] objectAtIndex:0] isEqualToString:@"en"]) {
+            NSString *baseTranslationPath = [[NSBundle jsq_messagesAssetBundle] pathForResource:@"Base" ofType:@"lproj"];
+            NSBundle *baseTranslationBundle = [NSBundle bundleWithPath:baseTranslationPath];
+            value = [baseTranslationBundle localizedStringForKey:key value:@"" table:@"JSQMessages"];
+        }
+    }
+    
+    return value;
 }
 
 @end


### PR DESCRIPTION
## Pull request checklist

- [X] All tests pass. Demo project builds and runs.
- [X] I have resolved any merge conflicts.
- [X] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This fixes issue #1903 

## What's in this pull request?

This PR fixes #1903 (chat bubbles don't get read in languages that only have a partial localization) by looking in the base localization for a localization string when it's missing from the current language's translation file.