### PR TITLE
Added support to set placeholder insets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This release closes the [8.0.0 milestone](https://github.com/jessesquires/JSQMes
 - Send button now can be turned on/off manually. (#1575, #1609) Thanks @sebastianludwig!
 - Video message items now have a custom thumbnail option. (#628, #709, #1408, #1823) Thanks @weekwood, @benjaminhallock!
 - A new class `JSQMessagesVideoThumbnailFactory` now can generate thumbnail images from `AVURLAsset`. (#709, #1823) Thanks @weekwood, @Lucashuang0802!
+- `JSQMessagesComposerTextView` now supports insets customization. (#1908)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This release closes the [8.0.0 milestone](https://github.com/jessesquires/JSQMes
 - Send button now can be turned on/off manually. (#1575, #1609) Thanks @sebastianludwig!
 - Video message items now have a custom thumbnail option. (#628, #709, #1408, #1823) Thanks @weekwood, @benjaminhallock!
 - A new class `JSQMessagesVideoThumbnailFactory` now can generate thumbnail images from `AVURLAsset`. (#709, #1823) Thanks @weekwood, @Lucashuang0802!
-- `JSQMessagesComposerTextView` now supports insets customization. (#1908)
+- Added a `placeHolderInsets` property to `JSQMessagesComposerTextView` to allow insetting the placeholder text. (#1908)
 
 ### Fixes
 

--- a/Documentation/apps_using_this_library.md
+++ b/Documentation/apps_using_this_library.md
@@ -46,4 +46,5 @@ These are the (known) apps that use `JSQMessagesViewController`. Submit a [pull 
 * [SnipSnap](http://go.snipsnap.it/messageui-scout)
 * [BubbleMe](https://itunes.apple.com/us/app/bubbleme/id1125325038)
 * [Social-Go](https://github.com/kingreza/Social-Go)
+* [multipeer-chat](https://github.com/J4awesome/multipeer-chat)
 * *Your app here, submit a [pull request](https://github.com/jessesquires/JSQMessagesViewController/compare)!*

--- a/JSQMessagesTests/ViewTests/JSQMessagesComposerTextViewTests.m
+++ b/JSQMessagesTests/ViewTests/JSQMessagesComposerTextViewTests.m
@@ -65,6 +65,20 @@
     XCTAssertEqual(self.textView.keyboardAppearance, UIKeyboardAppearanceDefault, @"Property should be equal to default value");
     XCTAssertEqual(self.textView.keyboardType, UIKeyboardTypeDefault, @"Property should be equal to default value");
     XCTAssertEqual(self.textView.returnKeyType, UIReturnKeyDefault, @"Property should be equal to default value");
+    
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.textView.placeHolderInsets, UIEdgeInsetsMake(5.0, 7.0, 5.0, 7.0)), @"Property should be equal to default value");
+}
+
+- (void)testComposerTextViewPlaceholderInsets
+{
+    // New insets to draw the placeholder
+    UIEdgeInsets placeholderInsets = UIEdgeInsetsMake(2.0, 4.0, 2.0, 0.0);
+    
+    // Set the new insets into the contentView
+    self.textView.placeHolderInsets = placeholderInsets;
+    
+    // Validate if placeholderInsets setter worked. We may validate the draw...
+    XCTAssertTrue(UIEdgeInsetsEqualToEdgeInsets(self.textView.placeHolderInsets, placeholderInsets), @"Property placeholderInsets should have changed to (2.0, 4.0, 2.0, 0.0)");
 }
 
 @end

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
@@ -55,6 +55,11 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) UIColor *placeHolderTextColor;
 
 /**
+ *  The insets to be used when the placeholder is drawn. The default value is `UIEdgeInsets(5.0, 7.0, 5.0, 7.0)`.
+ */
+@property (assign, nonatomic) UIEdgeInsets placeHolderInsets;
+
+/**
  *  The object that acts as the paste delegate of the text view.
  */
 @property (weak, nonatomic, nullable) id<JSQMessagesComposerTextViewPasteDelegate> pasteDelegate;

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -68,6 +68,7 @@
 
     _placeHolder = nil;
     _placeHolderTextColor = [UIColor lightGrayColor];
+    _placeHolderInsets = UIEdgeInsetsMake(5.0, 7.0, 5.0, 7.0);
 
     [self associateConstraints];
 
@@ -169,6 +170,16 @@
     [self setNeedsDisplay];
 }
 
+- (void)setPlaceHolderInsets:(UIEdgeInsets)placeHolderInsets
+{
+    if (UIEdgeInsetsEqualToEdgeInsets(placeHolderInsets, _placeHolderInsets)) {
+        return;
+    }
+    
+    _placeHolderInsets = placeHolderInsets;
+    [self setNeedsDisplay];
+}
+
 #pragma mark - UITextView overrides
 
 
@@ -220,8 +231,8 @@
 
     if ([self.text length] == 0 && self.placeHolder) {
         [self.placeHolderTextColor set];
-
-        [self.placeHolder drawInRect:CGRectInset(rect, 7.0f, 5.0f)
+        
+        [self.placeHolder drawInRect:UIEdgeInsetsInsetRect(rect, self.placeHolderInsets)
                       withAttributes:[self jsq_placeholderTextAttributes]];
     }
 }


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. Demo project builds and runs.
- [x] I have resolved any merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines), and reviewed the [contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md). Confirmation: 💪😎👊

#### This fixes issue #
#1907

## What's in this pull request?

Basically the changes are on the `JSQMessagesComposerTextView` class.

### Header File:
- A new property has created in the header file to allow change insets of the placeholder text

### ImplementationFile:
- Set property to default values of (5.0, 7.0, 5.0, 7.0) `UIEdgeInsetsMake(5.0, 7.0, 5.0, 7.0)` which is the same as `CGRectInset(rect, 5.0f, 7.0f)`
- Setter for the property overridden to force layout update when the insets change
- Changed `drawRect:` to use UIEdgeInsetsInsetRect instead of `CGRectInset`

If the developer using the lib doesn't provides any insets, the default values are used.

### Tests
- Changed `textView` init tests to validate if `placeholderInsets` matches the default values
- Added test to check if `placeholderInsets` setter is working correctly

### Notes

Why didn't i use `f` modifier in the `CGFloat` values?
CGFloat is a arch dependent type, which means it is a float in 32bits arch and a double in 64bits arch.
When we use `CGFloat` we force the value to be a float, to let the compiler decide.
I can change it to use `f` if necessary.

Cheers.
Thanks for the awesome work on the lib.