### PR TITLE
Resetting layout alongside view size transition.

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -301,7 +301,9 @@ static void JSQInstallWorkaroundForSheetPresentationIssue26295020(void) {
 
 - (void)viewWillTransitionToSize:(CGSize)size withTransitionCoordinator:(id<UIViewControllerTransitionCoordinator>)coordinator {
     [super viewWillTransitionToSize:size withTransitionCoordinator:coordinator];
-    [self jsq_resetLayoutAndCaches];
+    [coordinator animateAlongsideTransition:^(id<UIViewControllerTransitionCoordinatorContext> context) {
+        [self jsq_resetLayoutAndCaches];
+    } completion:nil];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection {


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. 
- [x] Demo project builds and runs.
- [x] I have resolved merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines). 

[Contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md) confirmation: 💪😎👊

#### This fixes an issue with/improves #1238

## What's in this pull request?

PR #1238 did introduce a layout reset in `viewWillTransitionToSize:withTransitionCoordinator:`. However the implementation does not use `animateAlongsideTransition:` of the coordinator - @harlanhaskins, did you have any specific reasons not to? This causes #680 to show when rotating the device. This might also fix #1257.