### PR TITLE
Fix alignment of bubbleTopLabel

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -585,8 +585,11 @@ JSQMessagesKeyboardControllerDelegate>
         needsAvatar = NO;
     }
 
+    CGFloat bubbleTopLabelInset = 15.0f;
     id<JSQMessageAvatarImageDataSource> avatarImageDataSource = nil;
     if (needsAvatar) {
+        bubbleTopLabelInset += isOutgoingMessage ? collectionView.collectionViewLayout.outgoingAvatarViewSize.width : collectionView.collectionViewLayout.incomingAvatarViewSize.width;
+
         avatarImageDataSource = [collectionView.dataSource collectionView:collectionView avatarImageDataForItemAtIndexPath:indexPath];
         if (avatarImageDataSource != nil) {
 
@@ -605,8 +608,6 @@ JSQMessagesKeyboardControllerDelegate>
     cell.cellTopLabel.attributedText = [collectionView.dataSource collectionView:collectionView attributedTextForCellTopLabelAtIndexPath:indexPath];
     cell.messageBubbleTopLabel.attributedText = [collectionView.dataSource collectionView:collectionView attributedTextForMessageBubbleTopLabelAtIndexPath:indexPath];
     cell.cellBottomLabel.attributedText = [collectionView.dataSource collectionView:collectionView attributedTextForCellBottomLabelAtIndexPath:indexPath];
-
-    CGFloat bubbleTopLabelInset = (avatarImageDataSource != nil) ? 60.0f : 15.0f;
 
     if (isOutgoingMessage) {
         cell.messageBubbleTopLabel.textInsets = UIEdgeInsetsMake(0.0f, 0.0f, 0.0f, bubbleTopLabelInset);


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. 
- [x] Demo project builds and runs.
- [x] I have resolved merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines). 

[Contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md) confirmation: 💪😎👊

## What's in this pull request?

The alignment of the bubbleTopLabel is currently too far to the right when avatars are used. This is because the offset is hardcoded, when it should be offset by the width of the avatar.

How it should be: 
![image](https://cloud.githubusercontent.com/assets/97820/22475427/ee61360c-e7ac-11e6-9048-e6e8306abf4b.png)

How it is before this PR:

![image](https://cloud.githubusercontent.com/assets/97820/22475471/0ea75478-e7ad-11e6-96c5-6848d6461d52.png)

How it is after this PR:
![image](https://cloud.githubusercontent.com/assets/97820/22475442/f737d722-e7ac-11e6-9bb3-b435343ab8a4.png)

