### PR TITLE
fix documentation

### DIFF
--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Creates and returns a new instance of `JSQMessagesToolbarButtonFactory` that uses
  *  the specified font for creating buttons.
  *
- *  @param A font that will be used for the buttons produced by the factory.
+ *  @param font font that will be used for the buttons produced by the factory.
  *
  *  @return An initialized `JSQMessagesToolbarButtonFactory` object.
  */

--- a/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
+++ b/JSQMessagesViewController/Factories/JSQMessagesToolbarButtonFactory.h
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Creates and returns a new instance of `JSQMessagesToolbarButtonFactory` that uses
  *  the specified font for creating buttons.
  *
- *  @param font font that will be used for the buttons produced by the factory.
+ *  @param font The font that will be used for the buttons produced by the factory.
  *
  *  @return An initialized `JSQMessagesToolbarButtonFactory` object.
  */

--- a/JSQMessagesViewController/Model/JSQAudioMediaItem.h
+++ b/JSQMessagesViewController/Model/JSQAudioMediaItem.h
@@ -65,7 +65,7 @@ didChangeAudioCategory:(NSString *)category
  *  Initializes and returns a audio media item having the given audioData.
  *
  *  @param audioData              The data object that contains the audio resource.
- *  @param audioViewConfiguration The view attributes to configure the appearance of the audio media view.
+ *  @param audioViewAttributes The view attributes to configure the appearance of the audio media view.
  *
  *  @return An initialized `JSQAudioMediaItem`.
  *

--- a/JSQMessagesViewController/Model/JSQMessagesViewAccessoryButtonDelegate.h
+++ b/JSQMessagesViewController/Model/JSQMessagesViewAccessoryButtonDelegate.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
  *  Notifies the delegate that the accessory button at the specified indexPath did receive a tap event.
  *
  *  @param messageView    The collection view object that is notifying the delegate of the tap event.
- *  @param indexPath      The index path of the item for which the accessory button was tapped.
+ *  @param path      The index path of the item for which the accessory button was tapped.
  */
 - (void)messageView:(JSQMessagesCollectionView *)messageView didTapAccessoryButtonAtIndexPath:(NSIndexPath *)path;
 


### PR DESCRIPTION
## What's in this pull request?

Fix documentation.
When CLANG_WARN_DOCUMENTATION_COMMENTS is enabled, compiler shows warnings with the discrepancy between the method and documentation 