### PR TITLE
change the Queue in MKMapSnapshotter to dispatch_get_main_queue()

### DIFF
--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -125,7 +125,7 @@
                       UIGraphicsEndImageContext();
 
                       if (completion) {
-                          completion();
+                          dispatch_async(dispatch_get_main_queue(), completion);
                       }
                   });
               }];

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -125,7 +125,7 @@
                       UIGraphicsEndImageContext();
 
                       if (completion) {
-                          dispatch_async(dispatch_get_main_queue(), completion);
+                          completion();
                       }
                   });
               }];

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -101,7 +101,7 @@
     
     MKMapSnapshotter *snapShotter = [[MKMapSnapshotter alloc] initWithOptions:options];
     
-    [snapShotter startWithQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
+    [snapShotter startWithQueue:dispatch_get_main_queue()
               completionHandler:^(MKMapSnapshot *snapshot, NSError *error) {
                   if (snapshot == nil) {
                       NSLog(@"%s Error creating map snapshot: %@", __PRETTY_FUNCTION__, error);
@@ -124,7 +124,7 @@
                   UIGraphicsEndImageContext();
                   
                   if (completion) {
-                      dispatch_async(dispatch_get_main_queue(), completion);
+                      completion();
                   }
               }];
 }

--- a/JSQMessagesViewController/Model/JSQLocationMediaItem.m
+++ b/JSQMessagesViewController/Model/JSQLocationMediaItem.m
@@ -101,31 +101,33 @@
     
     MKMapSnapshotter *snapShotter = [[MKMapSnapshotter alloc] initWithOptions:options];
     
-    [snapShotter startWithQueue:dispatch_get_main_queue()
+    [snapShotter startWithQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)
               completionHandler:^(MKMapSnapshot *snapshot, NSError *error) {
                   if (snapshot == nil) {
                       NSLog(@"%s Error creating map snapshot: %@", __PRETTY_FUNCTION__, error);
                       return;
                   }
-                  
-                  MKAnnotationView *pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:nil];
-                  CGPoint coordinatePoint = [snapshot pointForCoordinate:location.coordinate];
-                  UIImage *image = snapshot.image;
-                  
-                  coordinatePoint.x += pin.centerOffset.x - (CGRectGetWidth(pin.bounds) / 2.0);
-                  coordinatePoint.y += pin.centerOffset.y - (CGRectGetHeight(pin.bounds) / 2.0);
-                  
-                  UIGraphicsBeginImageContextWithOptions(image.size, YES, image.scale);
-                  {
-                      [image drawAtPoint:CGPointZero];
-                      [pin.image drawAtPoint:coordinatePoint];
-                      self.cachedMapSnapshotImage = UIGraphicsGetImageFromCurrentImageContext();
-                  }
-                  UIGraphicsEndImageContext();
-                  
-                  if (completion) {
-                      completion();
-                  }
+
+                  dispatch_async(dispatch_get_main_queue(), ^{
+                      MKAnnotationView *pin = [[MKPinAnnotationView alloc] initWithAnnotation:nil reuseIdentifier:nil];
+                      CGPoint coordinatePoint = [snapshot pointForCoordinate:location.coordinate];
+                      UIImage *image = snapshot.image;
+
+                      coordinatePoint.x += pin.centerOffset.x - (CGRectGetWidth(pin.bounds) / 2.0);
+                      coordinatePoint.y += pin.centerOffset.y - (CGRectGetHeight(pin.bounds) / 2.0);
+
+                      UIGraphicsBeginImageContextWithOptions(image.size, YES, image.scale);
+                      {
+                          [image drawAtPoint:CGPointZero];
+                          [pin.image drawAtPoint:coordinatePoint];
+                          self.cachedMapSnapshotImage = UIGraphicsGetImageFromCurrentImageContext();
+                      }
+                      UIGraphicsEndImageContext();
+
+                      if (completion) {
+                          completion();
+                      }
+                  });
               }];
 }
 


### PR DESCRIPTION
The reason: inside completion block UIKit classes (MKPinAnnotationView) were created. That usually stopped animations in all the application (the same effect as to call “UIView.setAnimationsEnabled(false)”)
Reproduce: send a lot of Location Items, and enter/exit the chat with that locations 3-5 times

## Pull request checklist

- [x] All tests pass. 
- [x] Demo project builds and runs.
- [x] I have resolved merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines). 

[Contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md) confirmation: ____

#### This fixes issue #

## What's in this pull request?

