### PR TITLE
Position edit menu over media items properly.

### DIFF
--- a/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
+++ b/JSQMessagesViewController/Controllers/JSQMessagesViewController.m
@@ -681,13 +681,14 @@ JSQMessagesKeyboardControllerDelegate>
 
 - (BOOL)collectionView:(JSQMessagesCollectionView *)collectionView shouldShowMenuForItemAtIndexPath:(NSIndexPath *)indexPath
 {
+    // Positioning the edit-menu properly requires tracking which item is selected.
+    self.selectedIndexPathForMenu = indexPath;
+
     //  disable menu for media messages
     id<JSQMessageData> messageItem = [collectionView.dataSource collectionView:collectionView messageDataForItemAtIndexPath:indexPath];
     if ([messageItem isMediaMessage]) {
         return NO;
     }
-
-    self.selectedIndexPathForMenu = indexPath;
 
     //  textviews are selectable to allow data detectors
     //  however, this allows the 'copy, define, select' UIMenuController to show


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. 
- [x] Demo project builds and runs.
- [x] I have resolved merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines). 

[Contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md) confirmation: 💪😎👊

#### This fixes issue: https://github.com/jessesquires/JSQMessagesViewController/issues/2068

The target rect of the UIMenu is set within `didReceiveMenuWillShowNotification`, however that menu is guarded to not run if `selectedIndexPathForMenu` is nil.

So even though we won't do anything with selectability, we need to ensure `didReceiveMenuWillShowNotification` is fully executed for media messages.

It's actually not such a big deal in the screenshots with wide media like images. But we have some custom media types which are more narrow, in which case the edit menu just floats in space.

**Before:**

<img width="487" alt="screen shot 2017-04-11 at 11 39 32 am" src="https://cloud.githubusercontent.com/assets/217057/24918162/6c37980a-1ead-11e7-8a9b-162eab3af09b.png">

**After:**

<img width="487" alt="screen shot 2017-04-11 at 11 38 35 am" src="https://cloud.githubusercontent.com/assets/217057/24918128/47b7fa88-1ead-11e7-84ab-3a9eadbf3d71.png">

