### PR TITLE
Fix for #1722 #1723 applied to Release 7.3

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -123,6 +123,8 @@
 
 - (void)didReceiveMenuWillShowNotification:(NSNotification *)notification
 {
+    [super didReceiveMenuWillShowNotification:notification];
+
     /**
      *  Display custom menu actions for cells.
      */


### PR DESCRIPTION
I am not sure why, but branch "release_7.3" does not have this fix. It appears the version we get in the pod file is newer than the release_7.3 branch

## Pull request checklist

- [X] All tests pass. 
- [X] Demo project builds and runs.
- [ ] I have resolved merge conflicts.
- [X] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines). 

[Contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md) confirmation: ____

#### This fixes issue #
I did not create this fix, just the pull request.  The fix for 1722 does not appear in the release_7.3 branch, but the fix applies to the branch, and does fix the issue

## What's in this pull request?
This includes a single change to add a call to the super class function.

```
- (void)didReceiveMenuWillShowNotification:(NSNotification *)notification
{
    [super didReceiveMenuWillShowNotification:notification];
    
    /**
     *  Display custom menu actions for cells.
     */

```