### PR TITLE
Synthesize pasteDelegate; fixes pasting crash on iOS 10

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -25,6 +25,8 @@
 
 @implementation JSQMessagesComposerTextView
 
+@synthesize pasteDelegate;
+
 #pragma mark - Initialization
 
 - (void)jsq_configureTextView


### PR DESCRIPTION
## Pull request checklist

- [x] All tests pass. 
- [x] Demo project builds and runs.
- [x] I have resolved merge conflicts.
- [x] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines). 

[Contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md) confirmation: 💪😎👊

#### This fixes issue #

Fixes #2176

## What's in this pull request?

Synthesizing the `pasteDelegate` fixes the crash and removes a warning about it in Xcode 9.

cc @chrisballinger (was told by Jessie to include you)
