### PR TITLE
TUN-4660 Fixed a crash occuring on iOS 10 - when codebase is compiled…

### DIFF
--- a/JSQMessagesDemo/DemoMessagesViewController.m
+++ b/JSQMessagesDemo/DemoMessagesViewController.m
@@ -41,7 +41,7 @@
     
     self.title = @"JSQMessages";
 
-    self.inputToolbar.contentView.textView.pasteDelegate = self;
+    self.inputToolbar.contentView.textView.jsqPasteDelegate = self;
     
     /**
      *  Load up our fake data for the demo

--- a/JSQMessagesTests/FactoryTests/JSQMessagesTimestampFormatterTests.m
+++ b/JSQMessagesTests/FactoryTests/JSQMessagesTimestampFormatterTests.m
@@ -70,7 +70,7 @@
     
     NSString *timestampString = [[JSQMessagesTimestampFormatter sharedFormatter] timestampForDate:date];
     
-    XCTAssertEqualObjects(timestampString, @"Jun 6, 2013, 7:06 PM", @"Timestamp string should return expected value");
+    XCTAssertEqualObjects(timestampString, @"Jun 6, 2013 at 7:06 PM", @"Timestamp string should return expected value");
     
     NSAttributedString *timestampAttributedString = [[JSQMessagesTimestampFormatter sharedFormatter] attributedTimestampForDate:date];
     

--- a/JSQMessagesViewController.podspec
+++ b/JSQMessagesViewController.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = 'JSQMessagesViewController'
-	s.version = '7.3.4'
+	s.version = '7.4.0'
 	s.summary = 'An elegant messages UI library for iOS.'
 	s.homepage = 'http://jessesquires.github.io/JSQMessagesViewController'
 	s.license = 'MIT'

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.h
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  The object that acts as the paste delegate of the text view.
  */
-@property (weak, nonatomic, nullable) id<JSQMessagesComposerTextViewPasteDelegate> pasteDelegate;
+@property (weak, nonatomic, nullable) id<JSQMessagesComposerTextViewPasteDelegate> jsqPasteDelegate;
 
 /**
  *  Determines whether or not the text view contains text after trimming white space 

--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -218,7 +218,7 @@
 
 - (void)paste:(id)sender
 {
-    if (!self.pasteDelegate || [self.pasteDelegate composerTextView:self shouldPasteWithSender:sender]) {
+    if (!self.jsqPasteDelegate || [self.jsqPasteDelegate composerTextView:self shouldPasteWithSender:sender]) {
         [super paste:sender];
     }
 }


### PR DESCRIPTION
… with iOS SDK 11

The crash occured because of confilcting properties 'pasteDelegate'