### PR TITLE
Fixing pasteDeleagte crash

### DIFF
--- a/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
+++ b/JSQMessagesViewController/Views/JSQMessagesComposerTextView.m
@@ -31,6 +31,7 @@
 @end
 
 @implementation JSQMessagesComposerTextView
+@synthesize pasteDelegate = _pasteDelegate;
 
 #pragma mark - Initialization
 


### PR DESCRIPTION
> This library is ⚠️ [deprecated](https://www.jessesquires.com/blog/officially-deprecating-jsqmessagesviewcontroller/) ⚠️ and is **only** accepting pull requests for critical bug fixes. Consider using [MessageKit](https://github.com/MessageKit/MessageKit) for new projects.

## Pull request checklist

- [ ] I understand that this library is ⚠️ [deprecated](https://www.jessesquires.com/blog/officially-deprecating-jsqmessagesviewcontroller/) ⚠️ and is **only** accepting pull requests for critical bug fixes.
- [ ] All tests pass. 
- [ ] Demo project builds and runs.
- [ ] I have resolved merge conflicts.
- [ ] I have followed the [coding style](https://github.com/jessesquires/HowToContribute#style-guidelines). 

[Contributing guidelines](https://github.com/jessesquires/JSQMessagesViewController/blob/develop/.github/CONTRIBUTING.md) confirmation: ____

#### This fixes issue #

## What's in this pull request?
Crash on iOS10 because of the pasteDeleagete property declaration.

